### PR TITLE
Add error message for datatype mismatch when reading OPC UA tag (#43)

### DIFF
--- a/src/Main/Root.cs
+++ b/src/Main/Root.cs
@@ -261,10 +261,26 @@ public partial class Root : Node3D
 		}
 	}
 
+	private T HandleOpcUaRead<T>(Guid guid)
+	{
+		var value = session.ReadValueAsync(opc_tags[guid]).Result.Value;
+		
+		if (value is T typedValue)
+		{
+			return typedValue;
+		}
+		else
+		{
+			string errorMessage = $"Expected {typeof(T)} but received {value.GetType()} for nodeid: {opc_tags[guid]}";
+			GD.PrintErr(errorMessage);
+			throw new InvalidCastException(errorMessage);
+		}
+	}
+
 	public async Task<bool> ReadBool(Guid guid)
 	{
 		if (Protocol == Protocols.opc_ua)
-			return Convert.ToBoolean(session.ReadValueAsync(opc_tags[guid]).Result.Value);
+			return HandleOpcUaRead<bool>(guid);
 		else
 			return Convert.ToBoolean(await bool_tags[guid].ReadAsync());
 	}
@@ -272,7 +288,7 @@ public partial class Root : Node3D
 	public async Task<int> ReadInt(Guid guid)
 	{
 		if (Protocol == Protocols.opc_ua)
-			return Convert.ToInt32(session.ReadValueAsync(opc_tags[guid]).Result.Value);
+			return HandleOpcUaRead<int>(guid);
 		else
 			return Convert.ToInt32(await bool_tags[guid].ReadAsync());
 	}
@@ -280,7 +296,7 @@ public partial class Root : Node3D
 	public async Task<float> ReadFloat(Guid guid)
 	{
 		if (Protocol == Protocols.opc_ua)
-			return (float)session.ReadValueAsync(opc_tags[guid]).Result.Value;
+			return HandleOpcUaRead<float>(guid);
 		else
 			return (float)(await float_tags[guid].ReadAsync());
 	}


### PR DESCRIPTION
This pull request fixes the error message handling for datatype mismatches when reading OPC UA tags.

- Added `HandleOpcUaRead<T>` method for better type handling and error messaging.
- Updated `ReadBool`, `ReadInt`, and `ReadFloat` to use the new generic method.

Fixes #43

![Screenshot 2024-09-09 112500](https://github.com/user-attachments/assets/07522426-cebb-42ed-8234-ed6f704fa919)
