### PR TITLE
Add whitespace settings to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,15 @@
-﻿[*.cs]
+﻿# Top-most EditorConfig file
+root = true
 
+[*]
+# Whitespace
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
 # CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = none
+
+[*.csproj]
+indent_style = space


### PR DESCRIPTION
This ensures consistency within the project.

I set indents to tabs. If you prefer we use spaces, that's fine. I just want it to be consistent.