### PR TITLE
Prevent `Box` and `Pallet` from warping to origin when a scene is reloaded while the simulation is running

### DIFF
--- a/src/Box/Box.cs
+++ b/src/Box/Box.cs
@@ -6,7 +6,8 @@ public partial class Box : Node3D
 	RigidBody3D rigidBody;
 	Vector3 initialPos;
 	public bool instanced = false;
-	private bool _paused = false;
+	bool _paused = false;
+	bool enable_inital_pos = false;
 
 	Root Main;
 	public override void _Ready()
@@ -15,12 +16,12 @@ public partial class Box : Node3D
 
 		if (Main != null)
 		{
-			rigidBody.Freeze = false;
-
 			if (Main.simulationRunning)
 			{
 				instanced = true;
 			}
+
+			rigidBody.Freeze = !Main.simulationRunning;
 		}
 	}
 
@@ -50,7 +51,7 @@ public partial class Box : Node3D
 
 	public void Select()
 	{
-		if (_paused || !Main.simulationRunning) return;
+		if (_paused || (Main != null && !Main.simulationRunning)) return;
 		if (rigidBody.Freeze)
 		{
 			rigidBody.TopLevel = false;
@@ -83,6 +84,7 @@ public partial class Box : Node3D
 		initialPos = GlobalPosition;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
+		enable_inital_pos = true;
 	}
 
 	void OnSimulationEnded()
@@ -105,7 +107,12 @@ public partial class Box : Node3D
 			rigidBody.LinearVelocity = Vector3.Zero;
 			rigidBody.AngularVelocity = Vector3.Zero;
 
-			GlobalPosition = initialPos;
+			//Work around for #83 
+			if (enable_inital_pos)
+			{
+				GlobalPosition = initialPos;
+			}
+
 			Rotation = Vector3.Zero;
 		}
 	}

--- a/src/Pallet/Pallet.cs
+++ b/src/Pallet/Pallet.cs
@@ -6,7 +6,8 @@ public partial class Pallet : Node3D
 	RigidBody3D rigidBody;
 	Vector3 initialPos;
 	public bool instanced = false;
-	private bool _paused = false;
+	bool _paused = false;
+	bool enable_inital_pos = false;
 
 	Root Main;
 
@@ -16,7 +17,12 @@ public partial class Pallet : Node3D
 
 		if (Main != null)
 		{
-			rigidBody.Freeze = false;
+			if (Main.simulationRunning)
+			{
+				instanced = true;
+			}
+
+			rigidBody.Freeze = !Main.simulationRunning;
 		}
 	}
 
@@ -29,11 +35,6 @@ public partial class Pallet : Node3D
 			Main.SimulationStarted += OnSimulationStarted;
 			Main.SimulationEnded += OnSimulationEnded;
 			Main.SimulationSetPaused += OnSimulationSetPaused;
-
-			if (Main.simulationRunning)
-			{
-				instanced = true;
-			}
 		}
 	}
 
@@ -51,7 +52,7 @@ public partial class Pallet : Node3D
 
 	public void Select()
 	{
-		if (_paused || !Main.simulationRunning) return;
+		if (_paused || (Main != null && !Main.simulationRunning)) return;
 		if (rigidBody.Freeze)
 		{
 			rigidBody.TopLevel = false;
@@ -84,6 +85,7 @@ public partial class Pallet : Node3D
 		initialPos = GlobalPosition;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
+		enable_inital_pos = true;
 	}
 
 	void OnSimulationEnded()
@@ -106,7 +108,12 @@ public partial class Pallet : Node3D
 			rigidBody.LinearVelocity = Vector3.Zero;
 			rigidBody.AngularVelocity = Vector3.Zero;
 
-			GlobalPosition = initialPos;
+			//Work around for #83 
+			if (enable_inital_pos)
+			{
+				GlobalPosition = initialPos;
+			}
+
 			Rotation = Vector3.Zero;
 		}
 	}


### PR DESCRIPTION
The ideal solution is to implement: https://github.com/Open-Industry-Project/Open-Industry-Project/issues/94, but this should be a good enough workaround just to prevent breaking the scene. 

Fixes: https://github.com/Open-Industry-Project/Open-Industry-Project/issues/83

