### PR TITLE
Cleanup whitespace for all C# files

### DIFF
--- a/src/BladeStop/BladeStop.cs
+++ b/src/BladeStop/BladeStop.cs
@@ -20,11 +20,11 @@ public partial class BladeStop : Node3D
 	public string tag;
 	[Export]
 	private int updateRate = 100;
-	
+
 	readonly Guid id = Guid.NewGuid();
 	double scan_interval = 0;
 	bool readSuccessful = false;
-	
+
 	bool active = false;
 	[Export] bool Active
 	{
@@ -38,7 +38,7 @@ public partial class BladeStop : Node3D
 		}
 	}
 	float activePos = 0.24f;
-	
+
 	float airPressureHeight = 0.0f;
 	[Export] float AirPressureHeight
 	{
@@ -57,21 +57,21 @@ public partial class BladeStop : Node3D
 			}
 		}
 	}
-	
+
 	StaticBody3D blade;
 	MeshInstance3D airPressureR;
 	MeshInstance3D airPressureL;
 	MeshInstance3D bladeCornerR;
 	MeshInstance3D bladeCornerL;
 	Node3D corners;
-	
+
 	bool keyHeld = false;
 	bool keyPressed = false;
 	bool running = false;
-	
+
 	Root main;
 	public Root Main { get; set; }
-	
+
 	public override void _ValidateProperty(Godot.Collections.Dictionary property)
 	{
 		string propertyName = property["name"].AsStringName();
@@ -81,7 +81,7 @@ public partial class BladeStop : Node3D
 			property["usage"] = (int)(EnableComms ? PropertyUsageFlags.Default : PropertyUsageFlags.NoEditor);
 		}
 	}
-	
+
 	public override void _Ready()
 	{
 		blade = GetNode<StaticBody3D>("Blade");
@@ -90,62 +90,62 @@ public partial class BladeStop : Node3D
 		bladeCornerR = GetNode<MeshInstance3D>("Corners/AirPressureR/BladeCornerR");
 		bladeCornerL = GetNode<MeshInstance3D>("Corners/AirPressureL/BladeCornerL");
 		corners = GetNode<Node3D>("Corners");
-		
+
 		blade.Position = new Vector3(blade.Position.X, airPressureHeight, blade.Position.Z);
 		airPressureR.Position = new Vector3(airPressureR.Position.X, airPressureHeight, airPressureR.Position.Z);
 		airPressureL.Position = new Vector3(airPressureL.Position.X, airPressureHeight, airPressureL.Position.Z);
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
 	public void Use()
 	{
 		Active = !Active;
 	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
-        if (blade != null && bladeCornerR != null && bladeCornerL != null)
-        {
-            if (active) Up();
-            else Down();
-        }
+		if (blade != null && bladeCornerR != null && bladeCornerL != null)
+		{
+			if (active) Up();
+			else Down();
+		}
 
-        if (EnableComms && readSuccessful && running)
-        {
-            scan_interval += delta;
-            if (scan_interval > (float)updateRate / 1000 && readSuccessful)
-            {
-                scan_interval = 0;
-                Task.Run(ScanTag);
-            }
-        }
+		if (EnableComms && readSuccessful && running)
+		{
+			scan_interval += delta;
+			if (scan_interval > (float)updateRate / 1000 && readSuccessful)
+			{
+				scan_interval = 0;
+				Task.Run(ScanTag);
+			}
+		}
 
-        Scale = new Vector3(1, 1, Scale.Z);
+		Scale = new Vector3(1, 1, Scale.Z);
 		foreach(Node3D child in corners.GetChildren())
 		{
 			child.Scale = new Vector3(1, 1, 1 / Scale.Z);
 		}
 	}
-	
+
 	void Up()
 	{
 		Tween tween = GetTree().CreateTween().SetEase(0).SetParallel(); // Set EaseIn
@@ -153,7 +153,7 @@ public partial class BladeStop : Node3D
 		tween.TweenProperty(bladeCornerR, "position", new Vector3(bladeCornerR.Position.X, activePos, bladeCornerR.Position.Z), 0.15f);
 		tween.TweenProperty(bladeCornerL, "position", new Vector3(bladeCornerL.Position.X, activePos, bladeCornerL.Position.Z), 0.15f);
 	}
-	
+
 	void Down()
 	{
 		Tween tween = GetTree().CreateTween().SetEase(0).SetParallel(); // Set EaseIn
@@ -161,7 +161,7 @@ public partial class BladeStop : Node3D
 		tween.TweenProperty(bladeCornerR, "position", new Vector3(bladeCornerR.Position.X, 0, bladeCornerR.Position.Z), 0.15f);
 		tween.TweenProperty(bladeCornerL, "position", new Vector3(bladeCornerL.Position.X, 0, bladeCornerL.Position.Z), 0.15f);
 	}
-	
+
 	void OnSimulationStarted()
 	{
 		running = true;
@@ -175,7 +175,7 @@ public partial class BladeStop : Node3D
 	{
 		running = false;
 	}
-	
+
 	async Task ScanTag()
 	{
 		try

--- a/src/Box/Box.cs
+++ b/src/Box/Box.cs
@@ -2,11 +2,11 @@ using Godot;
 
 [Tool]
 public partial class Box : Node3D
-{	
+{
 	RigidBody3D rigidBody;
 	Vector3 initialPos;
 	public bool instanced = false;
-    private bool _paused = false;
+	private bool _paused = false;
 
 	Root Main;
 	public override void _Ready()
@@ -15,76 +15,76 @@ public partial class Box : Node3D
 
 		if (Main != null)
 		{
-            rigidBody.Freeze = false;
+			rigidBody.Freeze = false;
 
-            if (Main.simulationRunning)
-            {
-                instanced = true;
-            }
-        }
+			if (Main.simulationRunning)
+			{
+				instanced = true;
+			}
+		}
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-            Main.SimulationSetPaused += OnSimulationSetPaused;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+			Main.SimulationSetPaused += OnSimulationSetPaused;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-            Main.SimulationSetPaused -= OnSimulationSetPaused;
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+			Main.SimulationSetPaused -= OnSimulationSetPaused;
 
-            if (instanced) QueueFree();
-        }
-    }
+			if (instanced) QueueFree();
+		}
+	}
 
 	public void Select()
 	{
-        if (_paused || !Main.simulationRunning) return;
-        if (rigidBody.Freeze)
-        {
-            rigidBody.TopLevel = false;
+		if (_paused || !Main.simulationRunning) return;
+		if (rigidBody.Freeze)
+		{
+			rigidBody.TopLevel = false;
 
-            if (rigidBody.Transform != Transform3D.Identity)
-            {
-                rigidBody.Transform = Transform3D.Identity;
-            }
-        }
-        else
-        {
-            rigidBody.TopLevel = true;
+			if (rigidBody.Transform != Transform3D.Identity)
+			{
+				rigidBody.Transform = Transform3D.Identity;
+			}
+		}
+		else
+		{
+			rigidBody.TopLevel = true;
 
-            if (Transform != rigidBody.Transform)
-            {
-                Transform = rigidBody.Transform;
-            }
-        }
-    }
+			if (Transform != rigidBody.Transform)
+			{
+				Transform = rigidBody.Transform;
+			}
+		}
+	}
 
-    public void Use()
-    {
+	public void Use()
+	{
 		rigidBody.Freeze = !rigidBody.Freeze;
-    }
-	
+	}
+
 	void OnSimulationStarted()
 	{
 		if (Main == null) return;
-		
+
 		initialPos = GlobalPosition;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
 	}
-	
+
 	void OnSimulationEnded()
 	{
 		if (instanced)
@@ -97,25 +97,25 @@ public partial class Box : Node3D
 		else
 		{
 			rigidBody.TopLevel = false;
-			
+
 			rigidBody.Position = Vector3.Zero;
 			rigidBody.Rotation = Vector3.Zero;
 			rigidBody.Scale = Vector3.One;
-			
+
 			rigidBody.LinearVelocity = Vector3.Zero;
 			rigidBody.AngularVelocity = Vector3.Zero;
-			
+
 			GlobalPosition = initialPos;
 			Rotation = Vector3.Zero;
 		}
 	}
 
-    void OnSimulationSetPaused(bool paused)
-    {
-        _paused = paused;
-        rigidBody.TopLevel = true;
-        rigidBody.Freeze = paused;
-        Transform = rigidBody.Transform;
-        rigidBody.TopLevel = !paused;
-    }
+	void OnSimulationSetPaused(bool paused)
+	{
+		_paused = paused;
+		rigidBody.TopLevel = true;
+		rigidBody.Freeze = paused;
+		Transform = rigidBody.Transform;
+		rigidBody.TopLevel = !paused;
+	}
 }

--- a/src/BoxSpawner/BoxSpawner.cs
+++ b/src/BoxSpawner/BoxSpawner.cs
@@ -5,21 +5,21 @@ public partial class BoxSpawner : Node3D
 {
 	[Export]
 	PackedScene scene;
-    private bool _disable = false;
-    [Export]
-    public bool Disable
-    {
-        get => _disable;
-        set
-        {
-            _disable = value;
-            if (!_disable)
-            {
-                scan_interval = spawnInterval;
-            }
-        }
-    }
-    [Export]
+	private bool _disable = false;
+	[Export]
+	public bool Disable
+	{
+		get => _disable;
+		set
+		{
+			_disable = value;
+			if (!_disable)
+			{
+				scan_interval = spawnInterval;
+			}
+		}
+	}
+	[Export]
 	public bool SpawnRandomScale = false;
 	[Export]
 	public Vector2 spawnRandomSize = new(0.5f, 1f);
@@ -34,45 +34,45 @@ public partial class BoxSpawner : Node3D
 	Vector3 _globalPosition;
 	Vector3 _scale;
 
-    public override void _Ready()
-    {
-        if (Main != null)
-        {
-            SetPhysicsProcess(Main.simulationRunning);
-        }
-    }
+	public override void _Ready()
+	{
+		if (Main != null)
+		{
+			SetPhysicsProcess(Main.simulationRunning);
+		}
+	}
 
-    public override void _EnterTree()
-    {
+	public override void _EnterTree()
+	{
 		SetNotifyLocalTransform(true);
 
 		scan_interval = spawnInterval;
 
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
 
 		_rotation = Rotation;
 		_globalPosition = GlobalPosition;
-    }
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		if (Main == null || Disable) return;
-		
+
 		scan_interval += (float)delta;
 		if (scan_interval > spawnInterval)
 		{
@@ -80,7 +80,7 @@ public partial class BoxSpawner : Node3D
 			SpawnBox();
 		}
 	}
-	
+
 	private void SpawnBox()
 	{
 		var box = (Box)scene.Instantiate();
@@ -95,15 +95,15 @@ public partial class BoxSpawner : Node3D
 		else
 		{
 			box.Scale = _scale;
-        }
+		}
 
 		box.Rotation = _rotation;
 		box.Position = _globalPosition;
 		box.instanced = true;
 
-        AddChild(box, forceReadableName:true);
+		AddChild(box, forceReadableName:true);
 		box.Owner = Main;
-    }
+	}
 
 	public void Use()
 	{
@@ -115,7 +115,7 @@ public partial class BoxSpawner : Node3D
 		SetPhysicsProcess(true);
 		scan_interval = spawnInterval;
 	}
-	
+
 	void OnSimulationEnded()
 	{
 		SetPhysicsProcess(false);

--- a/src/ChainTransfer/ChainTransfer.cs
+++ b/src/ChainTransfer/ChainTransfer.cs
@@ -100,10 +100,10 @@ public partial class ChainTransfer : Node3D
 
 	Vector3 prevScale;
 
-    bool keyHeld = false;
-    bool keyPressed = false;
+	bool keyHeld = false;
+	bool keyPressed = false;
 
-    public Root Main { get; set; }
+	public Root Main { get; set; }
 
 	public override void _ValidateProperty(Godot.Collections.Dictionary property)
 	{
@@ -161,8 +161,8 @@ public partial class ChainTransfer : Node3D
 
 	public override void _PhysicsProcess(double delta)
 	{
-        SetChainsPopupChains(popupChains);
-        
+		SetChainsPopupChains(popupChains);
+
 		if (running)
 		{
 			SetChainsSpeed(speed);

--- a/src/Conveyor/BeltConveyor.cs
+++ b/src/Conveyor/BeltConveyor.cs
@@ -136,23 +136,23 @@ public partial class BeltConveyor : Node3D, IBeltConveyor
 		conveyorEnd2.Speed = Speed;
 	}
 
-    public override void _EnterTree()
-    {	
+	public override void _EnterTree()
+	{
 		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
 
 			if (Main.simulationRunning)
 			{
 				running = true;
 			}
-        }
-    }
+		}
+	}
 
-    public override void _ExitTree()
+	public override void _ExitTree()
 	{
 		if (Main != null)
 		{
@@ -161,7 +161,7 @@ public partial class BeltConveyor : Node3D, IBeltConveyor
 		}
 	}
 
-    public override void _Process(double delta)
+	public override void _Process(double delta)
 	{
 		if (Scale.Y != 1)
 		{

--- a/src/Conveyor/CurvedBeltConveyor.cs
+++ b/src/Conveyor/CurvedBeltConveyor.cs
@@ -178,29 +178,29 @@ public partial class CurvedBeltConveyor : Node3D, IBeltConveyor
 		prevScaleX = Scale.X;
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
 
-            if (Main.simulationRunning)
-            {
-                running = true;
-            }
-        }
-    }
+			if (Main.simulationRunning)
+			{
+				running = true;
+			}
+		}
+	}
 
-    public override void _ExitTree()
+	public override void _ExitTree()
 	{
 		if (Main != null)
 		{
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
 	}
 
 	public override void _Process(double delta)

--- a/src/ConveyorLeg/ConveyorLeg.cs
+++ b/src/ConveyorLeg/ConveyorLeg.cs
@@ -66,7 +66,7 @@ public partial class ConveyorLeg : Node3D
 	{
 		if(Scale == prevScale) return;
 
-        if (legsSidesMaterial != null)
+		if (legsSidesMaterial != null)
 			legsSidesMaterial.SetShaderParameter("Scale", Scale.Y);
 
 		if (legsBars != null && legsBars.ParentScale != Scale.Y)
@@ -86,6 +86,6 @@ public partial class ConveyorLeg : Node3D
 		grab1.Scale = Vector3.One;
 		grab2.Scale = Vector3.One;
 
-        prevScale = Scale;
-    }
+		prevScale = Scale;
+	}
 }

--- a/src/ConveyorLeg/LegBars.cs
+++ b/src/ConveyorLeg/LegBars.cs
@@ -6,7 +6,7 @@ public partial class LegBars : Node3D
 {
 	[Export]
 	PackedScene legsBarScene;
-	
+
 	float barsDistance = 1.0f;
 	float parentScale = 1.0f;
 	[Export]
@@ -20,7 +20,7 @@ public partial class LegBars : Node3D
 		{
 			int roundedScale = Mathf.FloorToInt(value) + 1;
 			int barsCount = GetChildCount();
-			
+
 			for (; roundedScale - 1 > barsCount && roundedScale != 0; barsCount++)
 			{
 				SpawnBar();
@@ -29,16 +29,16 @@ public partial class LegBars : Node3D
 			{
 				RemoveBar();
 			}
-			
+
 			parentScale = value;
 		}
 	}
-	
+
 	ConveyorLeg owner;
 
-    Vector3 prevScale;
+	Vector3 prevScale;
 
-    public override void _Ready()
+	public override void _Ready()
 	{
 		owner = Owner as ConveyorLeg;
 		FixBars();
@@ -46,21 +46,21 @@ public partial class LegBars : Node3D
 		ParentScale = parentScale;
 	}
 
-    public override void _Process(double delta)
-    {
-        if (owner != null)
-        {
-            if (owner.Scale == prevScale) return;
-            
+	public override void _Process(double delta)
+	{
+		if (owner != null)
+		{
+			if (owner.Scale == prevScale) return;
+
 			Vector3 newScale = new(1 / owner.Scale.X, 1 / owner.Scale.Y, 1);
 			if(Scale != newScale)
 			{
-                Scale = new Vector3(1 / owner.Scale.X, 1 / owner.Scale.Y, 1);
-            }
+				Scale = new Vector3(1 / owner.Scale.X, 1 / owner.Scale.Y, 1);
+			}
 
-            prevScale = owner.Scale;
-        }
-    }
+			prevScale = owner.Scale;
+		}
+	}
 
 	void SpawnBar()
 	{
@@ -70,7 +70,7 @@ public partial class LegBars : Node3D
 		legsBar.Position = new Vector3(0, barsDistance * GetChildCount(), 0);
 		FixBars();
 	}
-	
+
 	void RemoveBar()
 	{
 		GetChild(GetChildCount() - 1).QueueFree();

--- a/src/Despawner/Despawner.cs
+++ b/src/Despawner/Despawner.cs
@@ -15,27 +15,27 @@ public partial class Despawner : Node3D
 		origin = area.Position;
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _Process(double delta)
+	public override void _Process(double delta)
 	{
 		if (Main == null) return;
 

--- a/src/DiffuseSensor/DiffuseSensor.cs
+++ b/src/DiffuseSensor/DiffuseSensor.cs
@@ -45,7 +45,7 @@ public partial class DiffuseSensor : Node3D
 				rayMarker.Visible = value;
 		}
 	}
-	
+
 	[Export]
 	Color beamBlockedColor;
 	[Export]
@@ -58,7 +58,7 @@ public partial class DiffuseSensor : Node3D
 	MeshInstance3D rayMesh;
 	CylinderMesh cylinderMesh;
 	StandardMaterial3D rayMaterial;
-	
+
 	Root Main;
 	public override void _ValidateProperty(Godot.Collections.Dictionary property)
 	{
@@ -88,33 +88,33 @@ public partial class DiffuseSensor : Node3D
 		rayMarker.Visible = showBeam;
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		PhysicsDirectSpaceState3D spaceState = GetWorld3D().DirectSpaceState;
 		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayMarker.GlobalPosition, rayMarker.GlobalPosition + GlobalTransform.Basis.Z * maxRange);
 		query.CollisionMask = 8;
 		var result = spaceState.IntersectRay(query);
-		
+
 		if (result.Count > 0)
 		{
 			blocked = true;
@@ -146,7 +146,7 @@ public partial class DiffuseSensor : Node3D
 
 		rayMesh.Position = new Vector3(0, 0, cylinderMesh.Height * 0.5f);
 	}
-	
+
 	void OnSimulationStarted()
 	{
 		running = true;
@@ -155,7 +155,7 @@ public partial class DiffuseSensor : Node3D
 			readSuccessful = Main.Connect(id, Root.DataType.Bool, Name, tag);
 		}
 	}
-	
+
 	void OnSimulationEnded()
 	{
 		running = false;

--- a/src/Diverter/Diverter.cs
+++ b/src/Diverter/Diverter.cs
@@ -57,46 +57,46 @@ public partial class Diverter : Node3D
 	{
 		diverterAnimator = GetNode<DiverterAnimator>("DiverterAnimator");
 	}
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
 	public void Use()
 	{
 		FireDivert = true;
 
-        Task.Delay(updateRate * 3).ContinueWith(t => FireDivert = false);
-    }
+		Task.Delay(updateRate * 3).ContinueWith(t => FireDivert = false);
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		if (FireDivert && !previousFireDivertState)
 		{
 			divert = true;
-			cycled = false;  
+			cycled = false;
 		}
 
 		if (divert && !cycled)
 		{
 			diverterAnimator.Fire(divertTime, divertDistance);
 			divert = false;
-			cycled = true;  
+			cycled = true;
 		}
 
 		previousFireDivertState = FireDivert;
@@ -113,12 +113,12 @@ public partial class Diverter : Node3D
 	}
 	void OnSimulationStarted()
 	{
-        running = true;
-        if (enableComms)
-        {
-            readSuccessful = Main.Connect(id, Root.DataType.Bool, Name, tag);
-        }
-    }
+		running = true;
+		if (enableComms)
+		{
+			readSuccessful = Main.Connect(id, Root.DataType.Bool, Name, tag);
+		}
+	}
 
 	void OnSimulationEnded()
 	{

--- a/src/Diverter/DiverterAnimator.cs
+++ b/src/Diverter/DiverterAnimator.cs
@@ -9,46 +9,46 @@ public partial class DiverterAnimator : Node3D
 		Red = 3,
 		Green = 4
 	}
-	
+
 	MeshInstance3D pusherMeshInstance;
 	StandardMaterial3D redLightMaterial;
 	StandardMaterial3D greenLightMaterial;
-	
+
 	MeshInstance3D part1;
 	Vector3 part1StartPos;
 	float part1MaximumZPos = 0.32f;
-	
+
 	MeshInstance3D part2;
 	Vector3 part2StartPos;
 	float part2MaximumZPos = 0.65f;
-	
+
 	RigidBody3D partEnd;
 	Vector3 partEndStartPos;
 	float partEndMaximumZPos = 1.0f;
-	
+
 	bool firing = false;
 
 	public override void _Ready()
 	{
 		pusherMeshInstance = GetNode<MeshInstance3D>("Pusher");
 		pusherMeshInstance.Mesh = pusherMeshInstance.Mesh.Duplicate() as Mesh;
-		
+
 		redLightMaterial = pusherMeshInstance.Mesh.SurfaceGetMaterial(3).Duplicate() as StandardMaterial3D;
 		greenLightMaterial = pusherMeshInstance.Mesh.SurfaceGetMaterial(4).Duplicate() as StandardMaterial3D;
-		
+
 		pusherMeshInstance.Mesh.SurfaceSetMaterial(3, redLightMaterial);
 		pusherMeshInstance.Mesh.SurfaceSetMaterial(4, greenLightMaterial);
-		
+
 		part1 = GetNode<MeshInstance3D>("Pusher/part1");
 		part1StartPos = part1.Position;
-		
+
 		part2 = GetNode<MeshInstance3D>("Pusher/part2");
 		part2StartPos = part2.Position;
-		
+
 		partEnd = GetNode<RigidBody3D>("Pusher/PartEnd");
 		partEndStartPos = partEnd.Position;
 	}
-	
+
 	void SetLampLight(LightColor lightColor, bool enabled)
 	{
 		StandardMaterial3D currentMaterial = pusherMeshInstance.Mesh.SurfaceGetMaterial((int) lightColor) as StandardMaterial3D;
@@ -57,7 +57,7 @@ public partial class DiverterAnimator : Node3D
 		else
 			currentMaterial.EmissionEnergyMultiplier = 0.0f;
 	}
-	
+
 	void Push(float time, float distance)
 	{
 		SetLampLight(LightColor.Green, true);
@@ -71,19 +71,19 @@ public partial class DiverterAnimator : Node3D
 		tween.Parallel().TweenProperty(partEnd, "position", partEndStartPos, time);
 		tween.TweenCallback(Callable.From(Finish));
 	}
-	
+
 	void Return()
 	{
 		SetLampLight(LightColor.Green, false);
 		SetLampLight(LightColor.Red, true);
 	}
-	
+
 	void Finish()
 	{
 		SetLampLight(LightColor.Red, false);
 		firing = false;
 	}
-	
+
 	public void Fire(float time, float distance)
 	{
 		if (!firing)
@@ -92,7 +92,7 @@ public partial class DiverterAnimator : Node3D
 			Push(time, distance);
 		}
 	}
-	
+
 	public void Disable()
 	{
 		Finish();

--- a/src/LaserSensor/LaserSensor.cs
+++ b/src/LaserSensor/LaserSensor.cs
@@ -60,7 +60,7 @@ public partial class LaserSensor : Node3D
 	MeshInstance3D rayMesh;
 	CylinderMesh cylinderMesh;
 	StandardMaterial3D rayMaterial;
-	
+
 	Root Main;
 	public override void _ValidateProperty(Godot.Collections.Dictionary property)
 	{
@@ -90,32 +90,32 @@ public partial class LaserSensor : Node3D
 		rayMarker.Visible = debugBeam;
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		PhysicsDirectSpaceState3D spaceState = GetWorld3D().DirectSpaceState;
 		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayMarker.GlobalPosition, rayMarker.GlobalPosition + GlobalTransform.Basis.Z * maxRange);
 		var result = spaceState.IntersectRay(query);
-		
+
 		if (result.Count > 0)
 		{
 			cylinderMesh.Height = rayMarker.GlobalPosition.DistanceTo((Vector3)result["position"]);

--- a/src/Main/Root.cs
+++ b/src/Main/Root.cs
@@ -66,7 +66,7 @@ public partial class Root : Node3D
 		set
 		{
 			_protocol = value;
-			NotifyPropertyListChanged(); 
+			NotifyPropertyListChanged();
 		}
 	}
 
@@ -93,12 +93,12 @@ public partial class Root : Node3D
 	readonly System.Collections.Generic.Dictionary<Guid, string> opc_tags = new();
 
 	public bool paused = false;
-	
+
 	public Array<Godot.Node> selectedNodes = [];
 
-    public Session session;
+	public Session session;
 
-    public enum Protocols
+	public enum Protocols
 	{
 		opc_ua,
 		ab_eip,
@@ -187,33 +187,33 @@ public partial class Root : Node3D
 				).Result;
 	}
 
-    public bool Connect(Guid guid, DataType dataType, string nodeName, string tagName)
-    {
-        if (Protocol == Protocols.opc_ua)
+	public bool Connect(Guid guid, DataType dataType, string nodeName, string tagName)
+	{
+		if (Protocol == Protocols.opc_ua)
 		{
-            if (string.IsNullOrWhiteSpace(tagName))
-            {
-                GD.PrintErr($"Error connecting tag NULL in node {nodeName}: Empty tag name");
-                return false;
-            }
+			if (string.IsNullOrWhiteSpace(tagName))
+			{
+				GD.PrintErr($"Error connecting tag NULL in node {nodeName}: Empty tag name");
+				return false;
+			}
 
-            if (tagName.Contains("ns=") && tagName.Contains(';') && tagName.Split(';')[1].StartsWith(" s="))
-            {
-                GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: space after namespaceIndex. Format should be: ns=<namespaceIndex>;<identifiertype>=<identifier>");
-                return false;
-            }
+			if (tagName.Contains("ns=") && tagName.Contains(';') && tagName.Split(';')[1].StartsWith(" s="))
+			{
+				GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: space after namespaceIndex. Format should be: ns=<namespaceIndex>;<identifiertype>=<identifier>");
+				return false;
+			}
 
-            try
-            {
-                NodeId.Parse(tagName);
-            }
-            catch (ArgumentException ex)
-            {
-                GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: {ex.Message}");
-                return false;
-            }
+			try
+			{
+				NodeId.Parse(tagName);
+			}
+			catch (ArgumentException ex)
+			{
+				GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: {ex.Message}");
+				return false;
+			}
 
-            var nodesToRead = new ReadValueIdCollection
+			var nodesToRead = new ReadValueIdCollection
 			{
 				new ReadValueId
 				{
@@ -222,16 +222,16 @@ public partial class Root : Node3D
 				}
 			};
 
-            session.Read(null, 0, TimestampsToReturn.Neither, nodesToRead, out DataValueCollection results, out _);
+			session.Read(null, 0, TimestampsToReturn.Neither, nodesToRead, out DataValueCollection results, out _);
 
-            if (StatusCode.IsBad(results[0].StatusCode))
-            {
-                GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: {results[0].StatusCode}");
-                return false;
-            }
+			if (StatusCode.IsBad(results[0].StatusCode))
+			{
+				GD.PrintErr($"Error connecting tag {tagName} in node {nodeName}: {results[0].StatusCode}");
+				return false;
+			}
 
-            opc_tags.Add(guid, tagName);
-        }
+			opc_tags.Add(guid, tagName);
+		}
 		else
 		{
 			if (dataType == DataType.Bool)
@@ -312,7 +312,7 @@ public partial class Root : Node3D
 	private T HandleOpcUaRead<T>(Guid guid)
 	{
 		var value = session.ReadValueAsync(opc_tags[guid]).Result.Value;
-		
+
 		if (value is T typedValue)
 		{
 			return typedValue;
@@ -477,75 +477,75 @@ public partial class Root : Node3D
 		}
 	}
 
-    public override void _Ready()
-    {
-        if (GetNodeOrNull("/root/SimulationEvents") != null)
-        {
-            var simulationEvents = GetNode("/root/SimulationEvents");
-            simulationEvents.Connect("simulation_started", new Callable(this, nameof(OnSimulationStarted2)));
-            simulationEvents.Connect("simulation_set_paused", new Callable(this, nameof(OnSimulationSetPaused2)));
-            simulationEvents.Connect("simulation_ended", new Callable(this, nameof(OnSimulationEnded2)));
-        }
-    }
+	public override void _Ready()
+	{
+		if (GetNodeOrNull("/root/SimulationEvents") != null)
+		{
+			var simulationEvents = GetNode("/root/SimulationEvents");
+			simulationEvents.Connect("simulation_started", new Callable(this, nameof(OnSimulationStarted2)));
+			simulationEvents.Connect("simulation_set_paused", new Callable(this, nameof(OnSimulationSetPaused2)));
+			simulationEvents.Connect("simulation_ended", new Callable(this, nameof(OnSimulationEnded2)));
+		}
+	}
 
-    public override void _EnterTree()
-    {        
+	public override void _EnterTree()
+	{
 		EditorInterface.Singleton.GetSelection().SelectionChanged += OnSelectionChanged;
-    }
+	}
 
-    public override void _ExitTree()
-    {
-        EditorInterface.Singleton.GetSelection().SelectionChanged -= OnSelectionChanged;
-    }
+	public override void _ExitTree()
+	{
+		EditorInterface.Singleton.GetSelection().SelectionChanged -= OnSelectionChanged;
+	}
 
 	public void OnSelectionChanged()
 	{
-        selectedNodes = EditorInterface.Singleton.GetSelection().GetSelectedNodes();
+		selectedNodes = EditorInterface.Singleton.GetSelection().GetSelectedNodes();
 		SelectNodes();
-    }
-	
+	}
+
 	void SelectNodes()
 	{
-        if (selectedNodes.Count > 0)
-        {
-            foreach (var node in selectedNodes)
-            {
-                if (node.HasMethod("Select"))
-                {
-                    node.Call("Select");
-                }
+		if (selectedNodes.Count > 0)
+		{
+			foreach (var node in selectedNodes)
+			{
+				if (node.HasMethod("Select"))
+				{
+					node.Call("Select");
+				}
 
-                if (node.HasMethod("Use") && use)
-                {
-                    node.Call("Use");
-                }
-            } 
-        }
-    }
+				if (node.HasMethod("Use") && use)
+				{
+					node.Call("Use");
+				}
+			}
+		}
+	}
 
-    public override void _Process(double delta)
-    {
+	public override void _Process(double delta)
+	{
 		use = false;
 
-        if (Input.IsPhysicalKeyPressed(Key.G))
-        {
-            if (!keyHeld)
-            {
+		if (Input.IsPhysicalKeyPressed(Key.G))
+		{
+			if (!keyHeld)
+			{
 				use = true;
 				keyHeld = true;
-            }
-        }
+			}
+		}
 
-        if (!Input.IsPhysicalKeyPressed(Key.G))
-        {
-            keyHeld = false;
-        }
+		if (!Input.IsPhysicalKeyPressed(Key.G))
+		{
+			keyHeld = false;
+		}
 
 
 		CallDeferred(MethodName.SelectNodes);
-    }
+	}
 
-    void OnSimulationStarted2()
+	void OnSimulationStarted2()
 	{
 		if (Protocol == Protocols.opc_ua && !string.IsNullOrEmpty(EndPoint))
 		{
@@ -566,7 +566,7 @@ public partial class Root : Node3D
 	void OnSimulationSetPaused2(bool _paused)
 	{
 		paused = _paused;
-		
+
 		if (paused)
 		{
 			ProcessMode = ProcessModeEnum.Disabled;
@@ -575,10 +575,10 @@ public partial class Root : Node3D
 		{
 			ProcessMode = ProcessModeEnum.Inherit;
 		}
-		
+
 		EmitSignal(SignalName.SimulationSetPaused, paused);
 	}
-	
+
 	void OnSimulationEnded2()
 	{
 		Start = false;

--- a/src/Pallet/Pallet.cs
+++ b/src/Pallet/Pallet.cs
@@ -2,90 +2,90 @@ using Godot;
 
 [Tool]
 public partial class Pallet : Node3D
-{	
+{
 	RigidBody3D rigidBody;
 	Vector3 initialPos;
 	public bool instanced = false;
-    private bool _paused = false;
+	private bool _paused = false;
 
 	Root Main;
-	
+
 	public override void _Ready()
 	{
 		rigidBody = GetNode<RigidBody3D>("RigidBody3D");
 
-        if (Main != null)
-        {
-            rigidBody.Freeze = false;
-        }
+		if (Main != null)
+		{
+			rigidBody.Freeze = false;
+		}
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-            Main.SimulationSetPaused += OnSimulationSetPaused;
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+			Main.SimulationSetPaused += OnSimulationSetPaused;
 
-            if (Main.simulationRunning)
-            {
-                instanced = true;
-            }
-        }
-    }
+			if (Main.simulationRunning)
+			{
+				instanced = true;
+			}
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-            Main.SimulationSetPaused -= OnSimulationSetPaused;
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+			Main.SimulationSetPaused -= OnSimulationSetPaused;
 
-            if (instanced) QueueFree();
-        }
-    }
+			if (instanced) QueueFree();
+		}
+	}
 
-    public void Select()
-    {
-        if (_paused || !Main.simulationRunning) return;
-        if (rigidBody.Freeze)
-        {
-            rigidBody.TopLevel = false;
+	public void Select()
+	{
+		if (_paused || !Main.simulationRunning) return;
+		if (rigidBody.Freeze)
+		{
+			rigidBody.TopLevel = false;
 
-            if (rigidBody.Transform != Transform3D.Identity)
-            {
-                rigidBody.Transform = Transform3D.Identity;
-            }
-        }
-        else
-        {
-            rigidBody.TopLevel = true;
+			if (rigidBody.Transform != Transform3D.Identity)
+			{
+				rigidBody.Transform = Transform3D.Identity;
+			}
+		}
+		else
+		{
+			rigidBody.TopLevel = true;
 
-            if (Transform != rigidBody.Transform)
-            {
-                Transform = rigidBody.Transform;
-            }
-        }
-    }
+			if (Transform != rigidBody.Transform)
+			{
+				Transform = rigidBody.Transform;
+			}
+		}
+	}
 
-    public void Use()
-    {
-        rigidBody.Freeze = !rigidBody.Freeze;
-    }
+	public void Use()
+	{
+		rigidBody.Freeze = !rigidBody.Freeze;
+	}
 
-    void OnSimulationStarted()
+	void OnSimulationStarted()
 	{
 		if (Owner == null) return;
-		
+
 		initialPos = GlobalPosition;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
 	}
-	
+
 	void OnSimulationEnded()
 	{
 		if (instanced)
@@ -111,12 +111,12 @@ public partial class Pallet : Node3D
 		}
 	}
 
-    void OnSimulationSetPaused(bool paused)
-    {
-        _paused = paused;
-        rigidBody.TopLevel = true;
-        rigidBody.Freeze = paused;
-        Transform = rigidBody.Transform;
-        rigidBody.TopLevel = !paused;
-    }
+	void OnSimulationSetPaused(bool paused)
+	{
+		_paused = paused;
+		rigidBody.TopLevel = true;
+		rigidBody.Freeze = paused;
+		Transform = rigidBody.Transform;
+		rigidBody.TopLevel = !paused;
+	}
 }

--- a/src/PalletSpawner/PalletSpawner.cs
+++ b/src/PalletSpawner/PalletSpawner.cs
@@ -5,21 +5,21 @@ public partial class PalletSpawner : Node3D
 {
 	[Export]
 	PackedScene scene;
-    private bool _disable = false;
-    [Export]
-    public bool Disable
-    {
-        get => _disable;
-        set
-        {
-            _disable = value;
-            if (!_disable)
-            {
-                scan_interval = spawnInterval;
-            }
-        }
-    }
-    [Export]
+	private bool _disable = false;
+	[Export]
+	public bool Disable
+	{
+		get => _disable;
+		set
+		{
+			_disable = value;
+			if (!_disable)
+			{
+				scan_interval = spawnInterval;
+			}
+		}
+	}
+	[Export]
 	public float spawnInterval = 3f;
 
 	private float scan_interval = 0;
@@ -30,38 +30,38 @@ public partial class PalletSpawner : Node3D
 	Vector3 _globalPosition;
 
 	public override void _Ready()
-    {
-        if (Main != null)
-        {
-            SetPhysicsProcess(Main.simulationRunning);
-        }
-    }
+	{
+		if (Main != null)
+		{
+			SetPhysicsProcess(Main.simulationRunning);
+		}
+	}
 
-    public override void _EnterTree()
-    {
+	public override void _EnterTree()
+	{
 		SetNotifyLocalTransform(true);
 
 		scan_interval = spawnInterval;
 
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		if (Main == null || Disable) return;
 
@@ -77,13 +77,13 @@ public partial class PalletSpawner : Node3D
 	{
 		var pallet = (Pallet)scene.Instantiate();
 
-        pallet.Rotation = _rotation;
-        pallet.Position = _globalPosition;
-        pallet.instanced = true;
+		pallet.Rotation = _rotation;
+		pallet.Position = _globalPosition;
+		pallet.instanced = true;
 
-        AddChild(pallet, forceReadableName: true);
-        pallet.Owner = Main;
-    }
+		AddChild(pallet, forceReadableName: true);
+		pallet.Owner = Main;
+	}
 
 	void OnSimulationStarted()
 	{

--- a/src/PushButton/PushButton.cs
+++ b/src/PushButton/PushButton.cs
@@ -23,7 +23,7 @@ public partial class PushButton : Node3D
 	[Export] string PushbuttonTag = "";
 	[Export] string LampTag = "";
 	[Export] int updateRate = 100;
-	
+
 	string text = "stop";
 	[Export] String Text
 	{
@@ -34,14 +34,14 @@ public partial class PushButton : Node3D
 		set
 		{
 			text = value;
-			
+
 			if (textMesh != null)
 			{
 				textMesh.Text = text;
 			}
 		}
 	}
-	
+
 	bool toggle = false;
 	[Export] bool Toggle
 	{
@@ -56,22 +56,22 @@ public partial class PushButton : Node3D
 				Pushbutton = false;
 		}
 	}
-	
+
 	bool pushbutton = false;
-	[Export] bool Pushbutton 
+	[Export] bool Pushbutton
 	{
-		get 
+		get
 		{
 			return pushbutton;
 		}
 		set
 		{
 			pushbutton = value;
-			
+
 			if (!Toggle && pushbutton)
 			{
-                Task.Delay(updateRate * 3).ContinueWith(t => pushbutton = false);
-                Tween tween = GetTree().CreateTween();
+				Task.Delay(updateRate * 3).ContinueWith(t => pushbutton = false);
+				Tween tween = GetTree().CreateTween();
 				tween.TweenProperty(buttonMesh, "position", new Vector3(0, 0, buttonPressedZPos), 0.035f);
 				tween.TweenInterval(0.2f);
 				tween.TweenProperty(buttonMesh, "position", Vector3.Zero, 0.02f);
@@ -85,7 +85,7 @@ public partial class PushButton : Node3D
 			}
 		}
 	}
-	
+
 	bool lamp = false;
 	[Export] bool Lamp
 	{
@@ -99,7 +99,7 @@ public partial class PushButton : Node3D
 			SetActive(lamp);
 		}
 	}
-	
+
 	Color buttonColor = new("#e73d30");
 	[Export] Color ButtonColor
 	{
@@ -113,26 +113,26 @@ public partial class PushButton : Node3D
 			SetButtonColor(buttonColor);
 		}
 	}
-	
+
 	MeshInstance3D textMeshInstance;
 	TextMesh textMesh;
-	
+
 	MeshInstance3D buttonMesh;
 	StandardMaterial3D buttonMaterial;
 	float buttonPressedZPos = -0.04f;
 	bool keyHeld = false;
 	bool keyPressed = false;
-	
+
 	bool readSuccessful = false;
 	bool running = false;
 	double scan_interval = 0;
-	
+
 	readonly Guid buttonId = Guid.NewGuid();
 	readonly Guid activeId = Guid.NewGuid();
-	
+
 	Root main;
 	public Root Main { get; set; }
-	
+
 	public override void _ValidateProperty(Godot.Collections.Dictionary property)
 	{
 		string propertyName = property["name"].AsStringName();
@@ -142,53 +142,53 @@ public partial class PushButton : Node3D
 			property["usage"] = (int)(EnableComms ? PropertyUsageFlags.Default : PropertyUsageFlags.NoEditor);
 		}
 	}
-	
+
 	public override void _Ready()
-	{	
+	{
 		// Assign 3D text
 		textMeshInstance = GetNode<MeshInstance3D>("TextMesh");
 		textMesh = textMeshInstance.Mesh.Duplicate() as TextMesh;
 		textMeshInstance.Mesh = textMesh;
 		textMesh.Text = text;
-		
+
 		// Assign button
 		buttonMesh = GetNode<MeshInstance3D>("Meshes/Button");
 		buttonMesh.Mesh = buttonMesh.Mesh.Duplicate() as Mesh;
 		buttonMaterial = buttonMesh.Mesh.SurfaceGetMaterial(0).Duplicate() as StandardMaterial3D;
 		buttonMesh.Mesh.SurfaceSetMaterial(0, buttonMaterial);
-		
+
 		// Initialize properties' states
 		SetButtonColor(ButtonColor);
 		SetActive(Lamp);
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
 	public void Use()
 	{
 		Pushbutton = !Pushbutton;
 	}
 
-    public override void _PhysicsProcess(double delta)
-	{		
+	public override void _PhysicsProcess(double delta)
+	{
 		if (enableComms && readSuccessful)
 		{
 			scan_interval += delta;
@@ -199,24 +199,24 @@ public partial class PushButton : Node3D
 			}
 		}
 	}
-	
+
 	async Task ScanTag()
 	{
 		if (PushbuttonTag != string.Empty)
 		{
 			await Main.Write(buttonId, Pushbutton);
 		}
-		
+
 		if (LampTag != string.Empty)
 		{
 			Lamp = await Main.ReadBool(activeId);
 		}
 	}
-	
+
 	void SetActive(bool newValue)
 	{
 		if (buttonMaterial == null) return;
-		
+
 		if (newValue)
 		{
 			buttonMaterial.EmissionEnergyMultiplier = 1.0f;
@@ -226,7 +226,7 @@ public partial class PushButton : Node3D
 			buttonMaterial.EmissionEnergyMultiplier = 0.0f;
 		}
 	}
-	
+
 	void SetButtonColor(Color newValue)
 	{
 		if (buttonMaterial != null)
@@ -235,16 +235,16 @@ public partial class PushButton : Node3D
 			buttonMaterial.Emission = newValue;
 		}
 	}
-	
+
 	void OnSimulationStarted()
 	{
-        running = true;
-        if (enableComms)
-        {
-            readSuccessful = Main.Connect(buttonId, Root.DataType.Bool, Name, PushbuttonTag) && Main.Connect(activeId, Root.DataType.Bool, Name, LampTag);
-        }
-    }
-	
+		running = true;
+		if (enableComms)
+		{
+			readSuccessful = Main.Connect(buttonId, Root.DataType.Bool, Name, PushbuttonTag) && Main.Connect(activeId, Root.DataType.Bool, Name, LampTag);
+		}
+	}
+
 	void OnSimulationEnded()
 	{
 		running = false;

--- a/src/RollerConveyor/CurvedRollerConveyor.cs
+++ b/src/RollerConveyor/CurvedRollerConveyor.cs
@@ -150,39 +150,39 @@ public partial class CurvedRollerConveyor : Node3D, IRollerConveyor
 		SetAllRollersSpeed();
 	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
 
-            if (Main.simulationRunning)
-            {
-                running = true;
-            }
-        }
-    }
+			if (Main.simulationRunning)
+			{
+				running = true;
+			}
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _Process(double delta)
-    {
+	public override void _Process(double delta)
+	{
 
-        Vector3 newScale = new(Scale.X, 1, Scale.X);
-        if (Scale != newScale)
-        {
-            Scale = new Vector3(Scale.X, 1, Scale.X);
-        }
+		Vector3 newScale = new(Scale.X, 1, Scale.X);
+		if (Scale != newScale)
+		{
+			Scale = new Vector3(Scale.X, 1, Scale.X);
+		}
 
 		// ReferenceDistance's PropertyHint depends on Scale.X
 		if (prevScaleX != Scale.X) {
@@ -196,9 +196,9 @@ public partial class CurvedRollerConveyor : Node3D, IRollerConveyor
 			uvOffset.X = (uvOffset.X % 1f + uvSpeed * (float)delta) % 1f;
 			rollerMaterial.Uv1Offset = uvOffset;
 		}
-    }
+	}
 
-    public override void _PhysicsProcess(double delta)
+	public override void _PhysicsProcess(double delta)
 	{
 		if (Scale.X > 0.5f)
 		{
@@ -251,7 +251,7 @@ public partial class CurvedRollerConveyor : Node3D, IRollerConveyor
 	private StandardMaterial3D TakeoverRollerMaterial()
 	{
 		StandardMaterial3D dupMaterial = rollersLow.GetChild<RollerCorner>(0).GetMaterial().Duplicate() as StandardMaterial3D;
-        foreach (Node3D rollers in (Span<Node3D>)([rollersLow, rollersMid, rollersHigh]))
+		foreach (Node3D rollers in (Span<Node3D>)([rollersLow, rollersMid, rollersHigh]))
 		{
 			foreach(RollerCorner roller in rollers.GetChildren())
 			{
@@ -282,12 +282,12 @@ public partial class CurvedRollerConveyor : Node3D, IRollerConveyor
 
 	void OnSimulationStarted()
 	{
-        running = true;
-        if (enableComms)
-        {
-            readSuccessful = Main.Connect(id, Root.DataType.Float, Name, tag);
-        }
-    }
+		running = true;
+		if (enableComms)
+		{
+			readSuccessful = Main.Connect(id, Root.DataType.Float, Name, tag);
+		}
+	}
 
 	void OnSimulationEnded()
 	{

--- a/src/RollerConveyor/RollerConveyor.cs
+++ b/src/RollerConveyor/RollerConveyor.cs
@@ -67,8 +67,8 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 	float lastWidth = baseWidth;
 	Transform3D previousTransform = Transform3D.Identity;
 
-    const float radius = 0.12f;
-    const float circumference = 2f * MathF.PI * radius;
+	const float radius = 0.12f;
+	const float circumference = 2f * MathF.PI * radius;
 	const float baseWidth = 2f;
 
 	Material metalMaterial;
@@ -114,13 +114,13 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 	{
 		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
+		if (Main != null)
 		{
 			Main.SimulationStarted += OnSimulationStarted;
 			Main.SimulationEnded += OnSimulationEnded;
 
-            running = Main.simulationRunning;
-        }
+			running = Main.simulationRunning;
+		}
 	}
 
 	public override void _ExitTree()
@@ -140,7 +140,7 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 		metalMaterial = meshInstance1.Mesh.SurfaceGetMaterial(0).Duplicate() as Material;
 		meshInstance1.Mesh.SurfaceSetMaterial(0, metalMaterial);
 		meshInstance2.Mesh.SurfaceSetMaterial(0, metalMaterial);
-    }
+	}
 
 	public override void _PhysicsProcess(double delta)
 	{
@@ -150,7 +150,7 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 
 		if (running)
 		{
-            rollerMaterial.Uv1Offset += new Vector3(4f * Speed / circumference * (float)delta, 0, 0);
+			rollerMaterial.Uv1Offset += new Vector3(4f * Speed / circumference * (float)delta, 0, 0);
 
 			if (enableComms && running && readSuccessful)
 			{

--- a/src/StackLight/StackLight.cs
+++ b/src/StackLight/StackLight.cs
@@ -77,7 +77,7 @@ public partial class StackLight : Node3D
 
 			segments = new_value;
 			FixSegments();
-			
+
 			if (segmentsContainer != null)
 			{
 				data.SetSegments(segments);
@@ -187,44 +187,44 @@ public partial class StackLight : Node3D
 
 		prevScale = Scale;
 
-        Rescale();
-    }
+		Rescale();
+	}
 
-    public override void _EnterTree()
-    {
-        Main = GetParent().GetTree().EditedSceneRoot as Root;
+	public override void _EnterTree()
+	{
+		Main = GetParent().GetTree().EditedSceneRoot as Root;
 
-        if (Main != null)
-        {
-            Main.SimulationStarted += OnSimulationStarted;
-            Main.SimulationEnded += OnSimulationEnded;
-        }
-    }
+		if (Main != null)
+		{
+			Main.SimulationStarted += OnSimulationStarted;
+			Main.SimulationEnded += OnSimulationEnded;
+		}
+	}
 
-    public override void _ExitTree()
-    {
-        if (Main != null)
-        {
-            Main.SimulationStarted -= OnSimulationStarted;
-            Main.SimulationEnded -= OnSimulationEnded;
-        }
-    }
+	public override void _ExitTree()
+	{
+		if (Main != null)
+		{
+			Main.SimulationStarted -= OnSimulationStarted;
+			Main.SimulationEnded -= OnSimulationEnded;
+		}
+	}
 
-    public override void _Process(double delta)
+	public override void _Process(double delta)
 	{
 		if(Scale != prevScale)
 		{
 			Rescale();
-        }
+		}
 		prevScale = Scale;
 	}
 
 	void Rescale()
 	{
-        Scale = new(Scale.X, Scale.Y, Scale.X);
-        bottomMesh.Scale = new(1, 1 / Scale.Y, 1);
-        midMesh.Scale = new(1, (1 / Scale.Y) * Scale.X, 1);
-    }
+		Scale = new(Scale.X, Scale.Y, Scale.X);
+		bottomMesh.Scale = new(1, 1 / Scale.Y, 1);
+		midMesh.Scale = new(1, (1 / Scale.Y) * Scale.X, 1);
+	}
 
 	void OnSimulationStarted()
 	{
@@ -255,8 +255,8 @@ public partial class StackLight : Node3D
 		{
 			Node3D segment = segmentScene.Instantiate() as Node3D;
 			segmentsContainer.AddChild(segment, forceReadableName: true);
-            segment.Owner = this;
-            segment.Position = new Vector3(0, segmentInitialYPos + (step * segment.GetIndex()), 0);
+			segment.Owner = this;
+			segment.Position = new Vector3(0, segmentInitialYPos + (step * segment.GetIndex()), 0);
 		}
 	}
 
@@ -267,14 +267,14 @@ public partial class StackLight : Node3D
 			segmentsContainer.GetChild(segmentsContainer.GetChildCount() - 1 - i).QueueFree();
 		}
 	}
-	
+
 	void FixSegments()
 	{
 		int childCount = segmentsContainer.GetChildCount();
 		int difference = childCount - segments;
-		
+
 		if (difference <= 0) return;
-		
+
 		for (int i = 0; i < difference; i++)
 		{
 			segmentsContainer.GetChild(segmentsContainer.GetChildCount() - 1 - i).QueueFree();

--- a/src/StackLight/StackLightData.cs
+++ b/src/StackLight/StackLightData.cs
@@ -8,11 +8,11 @@ public partial class StackLightData : Resource
 	public int segments = 0;
 	StackSegmentData segmentData = (StackSegmentData)ResourceLoader.Load("res://src/StackLight/StackSegmentData.tres");
 	[Export] public StackSegmentData[] segmentDatas = Array.Empty<StackSegmentData>();
-	
+
 	public void InitSegments(int count)
 	{
 		segments = count;
-		
+
 		if (segmentDatas.Length == 0)
 		{
 			segmentDatas = new StackSegmentData[segments];
@@ -31,13 +31,13 @@ public partial class StackLightData : Resource
 			segmentDatas = cache;
 		}
 	}
-	
+
 	public void SetSegments(int count)
 	{
 		if (count == segments) return;
-		
+
 		StackSegmentData[] cache = new StackSegmentData[count];
-		
+
 		if (count < segments)
 		{
 			for (int i = 0; i < count; i++)
@@ -55,7 +55,7 @@ public partial class StackLightData : Resource
 					cache[i] = segmentData.Duplicate() as StackSegmentData;
 			}
 		}
-		
+
 		segments = count;
 		segmentDatas = cache;
 	}

--- a/src/StackLight/StackSegment.cs
+++ b/src/StackLight/StackSegment.cs
@@ -26,10 +26,10 @@ public partial class StackSegment : Node3D
 	double scan_interval = 0;
 
 	readonly Guid id = Guid.NewGuid();
-	
+
 	Root main;
 	public Root Main { get; set; }
-	
+
 	public string tag = "";
 	StackSegmentData segmentData;
 	[Export]
@@ -49,53 +49,53 @@ public partial class StackSegment : Node3D
 			}
 
 			segmentData = value as StackSegmentData;
-			
+
 			if (material != null && segmentData != null)
 			{
 				SetActive(segmentData.Active);
 				SetSegmentColor(segmentData.SegmentColor);
 			}
-			
+
 			segmentData.TagChanged += SetTag;
 			segmentData.ActiveChanged += SetActive;
 			segmentData.ColorChanged += SetSegmentColor;
 		}
 	}
-	
+
 	MeshInstance3D meshInstance;
 	StandardMaterial3D material;
 	public override void _Ready()
 	{
 		Main = GetParent().GetTree().EditedSceneRoot as Root;
-		
+
 		if (Main != null)
 		{
 			Main.SimulationStarted += OnSimulationStarted;
 			Main.SimulationEnded += OnSimulationEnded;
 		}
-		
+
 		meshInstance = GetNode<MeshInstance3D>("LightMesh");
 		meshInstance.Mesh = meshInstance.Mesh.Duplicate() as Mesh;
-		
+
 		material = meshInstance.Mesh.SurfaceGetMaterial(0).Duplicate() as StandardMaterial3D;
 		meshInstance.Mesh.SurfaceSetMaterial(0, material);
-		
+
 		if (segmentData != null)
 		{
 			segmentData.TagChanged -= SetTag;
 			segmentData.ActiveChanged -= SetActive;
 			segmentData.ColorChanged -= SetSegmentColor;
 		}
-		
+
 		segmentData.enableComms = enableComms;
 		SetActive(segmentData.Active);
 		SetSegmentColor(segmentData.SegmentColor);
-		
+
 		segmentData.TagChanged += SetTag;
 		segmentData.ActiveChanged += SetActive;
 		segmentData.ColorChanged += SetSegmentColor;
 	}
-	
+
 	public override void _PhysicsProcess(double delta)
 	{
 		if (enableComms && running && readSuccessful)
@@ -108,7 +108,7 @@ public partial class StackSegment : Node3D
 			}
 		}
 	}
-	
+
 	async Task ScanTag()
 	{
 		if (segmentData.Tag != string.Empty)
@@ -116,12 +116,12 @@ public partial class StackSegment : Node3D
 			segmentData.Active = await Main.ReadBool(id);
 		}
 	}
-	
+
 	void SetTag(string newValue)
 	{
 		tag = newValue;
 	}
-	
+
 	void SetActive(bool newValue)
 	{
 		if (material == null) return;
@@ -134,7 +134,7 @@ public partial class StackSegment : Node3D
 			material.EmissionEnergyMultiplier = 0.0f;
 		}
 	}
-	
+
 	void SetSegmentColor(Color newValue)
 	{
 		if (material != null)
@@ -143,16 +143,16 @@ public partial class StackSegment : Node3D
 			material.Emission = newValue;
 		}
 	}
-	
+
 	void OnSimulationStarted()
 	{
-        running = true;
-        if (enableComms)
-        {
-            readSuccessful = Main.Connect(id, Root.DataType.Bool, Name, tag);
-        }
-    }
-	
+		running = true;
+		if (enableComms)
+		{
+			readSuccessful = Main.Connect(id, Root.DataType.Bool, Name, tag);
+		}
+	}
+
 	void OnSimulationEnded()
 	{
 		running = false;

--- a/src/StackLight/StackSegmentData.cs
+++ b/src/StackLight/StackSegmentData.cs
@@ -8,9 +8,9 @@ public partial class StackSegmentData : Resource
 	[Signal] public delegate void TagChangedEventHandler(string value);
 	[Signal] public delegate void ActiveChangedEventHandler(bool value);
 	[Signal] public delegate void ColorChangedEventHandler(Color value);
-	
+
 	public bool enableComms = false;
-	
+
 	string tag = "";
 	[Export] public string Tag
 	{
@@ -24,7 +24,7 @@ public partial class StackSegmentData : Resource
 			EmitSignal(SignalName.TagChanged, tag);
 		}
 	}
-	
+
 	bool active = false;
 	[Export] public bool Active
 	{
@@ -38,7 +38,7 @@ public partial class StackSegmentData : Resource
 			EmitSignal(SignalName.ActiveChanged, active);
 		}
 	}
-	
+
 	Color segmentColor = new(0.0f, 1.0f, 0.0f, 0.5f);
 	[Export] public Color SegmentColor
 	{


### PR DESCRIPTION
Trim trailing whitespace and convert all indentation from spaces to tabs.

Only space was changed. `git show --ignore-all-space` returns an empty diff.