### PR TITLE
Fix BoxSpawner regression (Jolt scale errors)

### DIFF
--- a/src/BoxSpawner/BoxSpawner.cs
+++ b/src/BoxSpawner/BoxSpawner.cs
@@ -56,6 +56,7 @@ public partial class BoxSpawner : Node3D
 			Main.SimulationEnded += OnSimulationEnded;
 		}
 
+		_scale = Scale;
 		_rotation = Rotation;
 		_globalPosition = GlobalPosition;
 	}


### PR DESCRIPTION
Fixes regression introduced in 9329d25 that affected BoxSpawners without SpawnRandomScale enabled.

Add missing initialization for `_scale` to fix Jolt errors.