### PR TITLE
Avoid continuous processing in ConveyorAssembly

### DIFF
--- a/parts/assemblies/BeltConveyorAssembly.tscn
+++ b/parts/assemblies/BeltConveyorAssembly.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=4 uid="uid://bqlkj4ar8q1ws"]
+[gd_scene load_steps=26 format=4 uid="uid://bqlkj4ar8q1ws"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_au6en"]
 [ext_resource type="PackedScene" uid="uid://dm55h6ap605bw" path="res://parts/BeltConveyor.tscn" id="2_kdap4"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_k3wlu"]
 [ext_resource type="PackedScene" uid="uid://cr8u3bta0skiy" path="res://parts/ConveyorLegBC.tscn" id="4_aq24s"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="6_0biw3"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyLegStands.cs" id="6_bki8d"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="9_sct53"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="12_jgtyw"]
 
@@ -273,7 +274,7 @@ Length = 4.0
 
 [node name="LegStands" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
-script = ExtResource("2_l2uq1")
+script = ExtResource("6_bki8d")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("4_aq24s")]
 transform = Transform3D(1, 0, 0, 0, 1.61792, 0, 0, 0, 1, -1.8, 0, 0)

--- a/parts/assemblies/BeltConveyorAssembly.tscn
+++ b/parts/assemblies/BeltConveyorAssembly.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=24 format=4 uid="uid://bqlkj4ar8q1ws"]
+[gd_scene load_steps=25 format=4 uid="uid://bqlkj4ar8q1ws"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_au6en"]
 [ext_resource type="PackedScene" uid="uid://dm55h6ap605bw" path="res://parts/BeltConveyor.tscn" id="2_kdap4"]
+[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="2_l2uq1"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_k3wlu"]
 [ext_resource type="PackedScene" uid="uid://cr8u3bta0skiy" path="res://parts/ConveyorLegBC.tscn" id="4_aq24s"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="6_0biw3"]
@@ -248,11 +249,13 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
+script = ExtResource("2_l2uq1")
 
 [node name="Conveyor" parent="Conveyors" instance=ExtResource("2_kdap4")]
 
 [node name="LeftSide" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
+script = ExtResource("2_l2uq1")
 
 [node name="AutoSideGuard1" parent="LeftSide" instance=ExtResource("3_k3wlu")]
 transform = Transform3D(4, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -261,6 +264,7 @@ Length = 4.0
 
 [node name="RightSide" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
+script = ExtResource("2_l2uq1")
 
 [node name="AutoSideGuard1" parent="RightSide" instance=ExtResource("3_k3wlu")]
 transform = Transform3D(-4, 0, -8.74228e-08, 0, 1, 0, 3.49691e-07, 0, -1, 0, 0, 0)
@@ -269,6 +273,7 @@ Length = 4.0
 
 [node name="LegStands" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+script = ExtResource("2_l2uq1")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("4_aq24s")]
 transform = Transform3D(1, 0, 0, 0, 1.61792, 0, 0, 0, 1, -1.8, 0, 0)

--- a/parts/assemblies/BeltConveyorAssembly.tscn
+++ b/parts/assemblies/BeltConveyorAssembly.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_au6en"]
 [ext_resource type="PackedScene" uid="uid://dm55h6ap605bw" path="res://parts/BeltConveyor.tscn" id="2_kdap4"]
-[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="2_l2uq1"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="2_l2uq1"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_k3wlu"]
 [ext_resource type="PackedScene" uid="uid://cr8u3bta0skiy" path="res://parts/ConveyorLegBC.tscn" id="4_aq24s"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="6_0biw3"]

--- a/parts/assemblies/BeltConveyorAssembly.tscn
+++ b/parts/assemblies/BeltConveyorAssembly.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=26 format=4 uid="uid://bqlkj4ar8q1ws"]
+[gd_scene load_steps=27 format=4 uid="uid://bqlkj4ar8q1ws"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_au6en"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyConveyors.cs" id="2_1jum7"]
 [ext_resource type="PackedScene" uid="uid://dm55h6ap605bw" path="res://parts/BeltConveyor.tscn" id="2_kdap4"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="2_l2uq1"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_k3wlu"]
@@ -250,7 +251,7 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
-script = ExtResource("2_l2uq1")
+script = ExtResource("2_1jum7")
 
 [node name="Conveyor" parent="Conveyors" instance=ExtResource("2_kdap4")]
 

--- a/parts/assemblies/CurvedBeltConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedBeltConveyorAssembly.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=21 format=4 uid="uid://dvpvhht5hn7ww"]
+[gd_scene load_steps=22 format=4 uid="uid://dvpvhht5hn7ww"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_tp652"]
 [ext_resource type="PackedScene" uid="uid://b2hnylsj67c5m" path="res://parts/ConveyorLegCBC.tscn" id="2_0xmjf"]
 [ext_resource type="PackedScene" uid="uid://6vu4cx2v1ltg" path="res://parts/CurvedBeltConveyor.tscn" id="3_a54t1"]
 [ext_resource type="PackedScene" uid="uid://b567tts2001h8" path="res://parts/SideGuardCBC.tscn" id="4_3p6hp"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyConveyors.cs" id="4_053qp"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="4_hnkat"]
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_6obdt"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="7_tjaqc"]
@@ -187,7 +188,7 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
-script = ExtResource("4_hnkat")
+script = ExtResource("4_053qp")
 
 [node name="ConveyorCorner" parent="Conveyors" instance=ExtResource("3_a54t1")]
 transform = Transform3D(1, 0, -8.74229e-08, 0, 1, 0, 8.74229e-08, 0, 1, 0, 0, 0)

--- a/parts/assemblies/CurvedBeltConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedBeltConveyorAssembly.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://b2hnylsj67c5m" path="res://parts/ConveyorLegCBC.tscn" id="2_0xmjf"]
 [ext_resource type="PackedScene" uid="uid://6vu4cx2v1ltg" path="res://parts/CurvedBeltConveyor.tscn" id="3_a54t1"]
 [ext_resource type="PackedScene" uid="uid://b567tts2001h8" path="res://parts/SideGuardCBC.tscn" id="4_3p6hp"]
-[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_hnkat"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="4_hnkat"]
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_6obdt"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="7_tjaqc"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="9_54jvh"]

--- a/parts/assemblies/CurvedBeltConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedBeltConveyorAssembly.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=19 format=4 uid="uid://dvpvhht5hn7ww"]
+[gd_scene load_steps=20 format=4 uid="uid://dvpvhht5hn7ww"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_tp652"]
 [ext_resource type="PackedScene" uid="uid://b2hnylsj67c5m" path="res://parts/ConveyorLegCBC.tscn" id="2_0xmjf"]
 [ext_resource type="PackedScene" uid="uid://6vu4cx2v1ltg" path="res://parts/CurvedBeltConveyor.tscn" id="3_a54t1"]
 [ext_resource type="PackedScene" uid="uid://b567tts2001h8" path="res://parts/SideGuardCBC.tscn" id="4_3p6hp"]
+[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_hnkat"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="7_tjaqc"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="9_54jvh"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="12_r4t1m"]
@@ -185,17 +186,20 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("4_hnkat")
 
 [node name="ConveyorCorner" parent="Conveyors" instance=ExtResource("3_a54t1")]
 transform = Transform3D(1, 0, -8.74229e-08, 0, 1, 0, 8.74229e-08, 0, 1, 0, 0, 0)
 
 [node name="LeftSide" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("4_hnkat")
 
 [node name="AutoSideGuard1" parent="LeftSide" instance=ExtResource("4_3p6hp")]
 mesh = SubResource("ArrayMesh_gg8bi")
 
 [node name="LegStands" type="Node3D" parent="."]
+script = ExtResource("4_hnkat")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_0xmjf")]
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1.5, 0, 1, 0, -4.37114e-08, -1.5, 0, -6.55671e-08)

--- a/parts/assemblies/CurvedBeltConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedBeltConveyorAssembly.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=20 format=4 uid="uid://dvpvhht5hn7ww"]
+[gd_scene load_steps=21 format=4 uid="uid://dvpvhht5hn7ww"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_tp652"]
 [ext_resource type="PackedScene" uid="uid://b2hnylsj67c5m" path="res://parts/ConveyorLegCBC.tscn" id="2_0xmjf"]
 [ext_resource type="PackedScene" uid="uid://6vu4cx2v1ltg" path="res://parts/CurvedBeltConveyor.tscn" id="3_a54t1"]
 [ext_resource type="PackedScene" uid="uid://b567tts2001h8" path="res://parts/SideGuardCBC.tscn" id="4_3p6hp"]
 [ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_hnkat"]
+[ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_6obdt"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="7_tjaqc"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="9_54jvh"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="12_r4t1m"]
@@ -199,7 +200,7 @@ script = ExtResource("4_hnkat")
 mesh = SubResource("ArrayMesh_gg8bi")
 
 [node name="LegStands" type="Node3D" parent="."]
-script = ExtResource("4_hnkat")
+script = ExtResource("7_6obdt")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_0xmjf")]
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1.5, 0, 1, 0, -4.37114e-08, -1.5, 0, -6.55671e-08)

--- a/parts/assemblies/CurvedRollerConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedRollerConveyorAssembly.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=21 format=4 uid="uid://bdeaerf4lvemx"]
+[gd_scene load_steps=22 format=4 uid="uid://bdeaerf4lvemx"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_qvlhq"]
 [ext_resource type="PackedScene" uid="uid://somtwmiih8bb" path="res://parts/ConveyorLegCRC.tscn" id="2_p1nhg"]
 [ext_resource type="PackedScene" uid="uid://c3cdcxifx4eej" path="res://parts/CurvedRollerConveyor.tscn" id="3_l832a"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="4_0yc54"]
 [ext_resource type="PackedScene" uid="uid://c4xqkx88xf1dy" path="res://parts/CRCSideGuard.tscn" id="4_hvqu8"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyConveyors.cs" id="4_lkxdi"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="6_oqa7e"]
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_vrbyf"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_k0egk"]
@@ -187,7 +188,7 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
-script = ExtResource("4_0yc54")
+script = ExtResource("4_lkxdi")
 
 [node name="CurvedRollerConveyor" parent="Conveyors" instance=ExtResource("3_l832a")]
 

--- a/parts/assemblies/CurvedRollerConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedRollerConveyorAssembly.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_qvlhq"]
 [ext_resource type="PackedScene" uid="uid://somtwmiih8bb" path="res://parts/ConveyorLegCRC.tscn" id="2_p1nhg"]
 [ext_resource type="PackedScene" uid="uid://c3cdcxifx4eej" path="res://parts/CurvedRollerConveyor.tscn" id="3_l832a"]
-[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_0yc54"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="4_0yc54"]
 [ext_resource type="PackedScene" uid="uid://c4xqkx88xf1dy" path="res://parts/CRCSideGuard.tscn" id="4_hvqu8"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="6_oqa7e"]
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_vrbyf"]

--- a/parts/assemblies/CurvedRollerConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedRollerConveyorAssembly.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=19 format=4 uid="uid://bdeaerf4lvemx"]
+[gd_scene load_steps=20 format=4 uid="uid://bdeaerf4lvemx"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_qvlhq"]
 [ext_resource type="PackedScene" uid="uid://somtwmiih8bb" path="res://parts/ConveyorLegCRC.tscn" id="2_p1nhg"]
 [ext_resource type="PackedScene" uid="uid://c3cdcxifx4eej" path="res://parts/CurvedRollerConveyor.tscn" id="3_l832a"]
+[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_0yc54"]
 [ext_resource type="PackedScene" uid="uid://c4xqkx88xf1dy" path="res://parts/CRCSideGuard.tscn" id="4_hvqu8"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="6_oqa7e"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_k0egk"]
@@ -185,16 +186,19 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
+script = ExtResource("4_0yc54")
 
 [node name="CurvedRollerConveyor" parent="Conveyors" instance=ExtResource("3_l832a")]
 
 [node name="LeftSide" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.99992, 0)
+script = ExtResource("4_0yc54")
 
 [node name="AutoSideGuard1" parent="LeftSide" instance=ExtResource("4_hvqu8")]
 mesh = SubResource("ArrayMesh_5ou2u")
 
 [node name="LegStands" type="Node3D" parent="."]
+script = ExtResource("4_0yc54")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_p1nhg")]
 transform = Transform3D(-4.37114e-08, 0, -1.055, 0, 1.49992, 0, 1, 0, -4.61155e-08, -1.5, 0, -1.31134e-07)

--- a/parts/assemblies/CurvedRollerConveyorAssembly.tscn
+++ b/parts/assemblies/CurvedRollerConveyorAssembly.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=4 uid="uid://bdeaerf4lvemx"]
+[gd_scene load_steps=21 format=4 uid="uid://bdeaerf4lvemx"]
 
 [ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssembly.cs" id="1_qvlhq"]
 [ext_resource type="PackedScene" uid="uid://somtwmiih8bb" path="res://parts/ConveyorLegCRC.tscn" id="2_p1nhg"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="4_0yc54"]
 [ext_resource type="PackedScene" uid="uid://c4xqkx88xf1dy" path="res://parts/CRCSideGuard.tscn" id="4_hvqu8"]
 [ext_resource type="Shader" uid="uid://b4wwduhuvem3q" path="res://assets/3DModels/Shaders/SideGuardShaderCBC.tres" id="6_oqa7e"]
+[ext_resource type="Script" path="res://src/Assembly/CurvedConveyorAssemblyLegStands.cs" id="7_vrbyf"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_k0egk"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="11_vdin8"]
 
@@ -198,7 +199,7 @@ script = ExtResource("4_0yc54")
 mesh = SubResource("ArrayMesh_5ou2u")
 
 [node name="LegStands" type="Node3D" parent="."]
-script = ExtResource("4_0yc54")
+script = ExtResource("7_vrbyf")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_p1nhg")]
 transform = Transform3D(-4.37114e-08, 0, -1.055, 0, 1.49992, 0, 1, 0, -4.61155e-08, -1.5, 0, -1.31134e-07)

--- a/parts/assemblies/RollerConveyorAssembly.tscn
+++ b/parts/assemblies/RollerConveyorAssembly.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=24 format=4 uid="uid://i8xb8locnhi5"]
+[gd_scene load_steps=25 format=4 uid="uid://i8xb8locnhi5"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_nkn8g"]
 [ext_resource type="PackedScene" uid="uid://rv5ef61beh35" path="res://parts/ConveyorLegRC.tscn" id="2_a0feq"]
 [ext_resource type="PackedScene" uid="uid://dg47c07xr4ksu" path="res://parts/RollerConveyor.tscn" id="2_pqgj2"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_l6sjy"]
+[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="3_uu1p1"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="7_ns4py"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_64v37"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="11_0gvht"]
@@ -249,12 +250,14 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("3_uu1p1")
 
 [node name="RollerConveyor" parent="Conveyors" instance=ExtResource("2_pqgj2")]
 transform = Transform3D(4, 0, 0, 0, 1, -1.50996e-07, 0, 1.50996e-07, 1, 0, 0, 0)
 
 [node name="LeftSide" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("3_uu1p1")
 
 [node name="AutoSideGuard1" parent="LeftSide" instance=ExtResource("3_l6sjy")]
 transform = Transform3D(4, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -263,6 +266,7 @@ Length = 4.0
 
 [node name="RightSide" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("3_uu1p1")
 
 [node name="AutoSideGuard1" parent="RightSide" instance=ExtResource("3_l6sjy")]
 transform = Transform3D(-4, 0, -8.74228e-08, 0, 1, 0, 3.49691e-07, 0, -1, 0, 0, 0)
@@ -271,6 +275,7 @@ Length = 4.0
 
 [node name="LegStands" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+script = ExtResource("3_uu1p1")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_a0feq")]
 transform = Transform3D(1, 0, 0, 0, 1.618, 0, 0, 0, 1.055, -1.8, 0, 0)

--- a/parts/assemblies/RollerConveyorAssembly.tscn
+++ b/parts/assemblies/RollerConveyorAssembly.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=26 format=4 uid="uid://i8xb8locnhi5"]
+[gd_scene load_steps=27 format=4 uid="uid://i8xb8locnhi5"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_nkn8g"]
 [ext_resource type="PackedScene" uid="uid://rv5ef61beh35" path="res://parts/ConveyorLegRC.tscn" id="2_a0feq"]
 [ext_resource type="PackedScene" uid="uid://dg47c07xr4ksu" path="res://parts/RollerConveyor.tscn" id="2_pqgj2"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_l6sjy"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyConveyors.cs" id="3_n3k02"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="3_uu1p1"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="7_ns4py"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyLegStands.cs" id="7_y435x"]
@@ -251,7 +252,7 @@ metadata/_edit_group_ = true
 
 [node name="Conveyors" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
-script = ExtResource("3_uu1p1")
+script = ExtResource("3_n3k02")
 
 [node name="RollerConveyor" parent="Conveyors" instance=ExtResource("2_pqgj2")]
 transform = Transform3D(4, 0, 0, 0, 1, -1.50996e-07, 0, 1.50996e-07, 1, 0, 0, 0)

--- a/parts/assemblies/RollerConveyorAssembly.tscn
+++ b/parts/assemblies/RollerConveyorAssembly.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://rv5ef61beh35" path="res://parts/ConveyorLegRC.tscn" id="2_a0feq"]
 [ext_resource type="PackedScene" uid="uid://dg47c07xr4ksu" path="res://parts/RollerConveyor.tscn" id="2_pqgj2"]
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_l6sjy"]
-[ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="3_uu1p1"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyChild.cs" id="3_uu1p1"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="7_ns4py"]
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyLegStands.cs" id="7_y435x"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_64v37"]

--- a/parts/assemblies/RollerConveyorAssembly.tscn
+++ b/parts/assemblies/RollerConveyorAssembly.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=4 uid="uid://i8xb8locnhi5"]
+[gd_scene load_steps=26 format=4 uid="uid://i8xb8locnhi5"]
 
 [ext_resource type="Script" path="res://src/Assembly/ConveyorAssembly.cs" id="1_nkn8g"]
 [ext_resource type="PackedScene" uid="uid://rv5ef61beh35" path="res://parts/ConveyorLegRC.tscn" id="2_a0feq"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://dvjrx5crpqs5f" path="res://parts/SideGuard.tscn" id="3_l6sjy"]
 [ext_resource type="Script" path="res://src/Assembly/TransformMonitoredNode3D.cs" id="3_uu1p1"]
 [ext_resource type="Shader" uid="uid://wtu5yyfpdcgl" path="res://assets/3DModels/Shaders/MetalShaderSideGuard.tres" id="7_ns4py"]
+[ext_resource type="Script" path="res://src/Assembly/ConveyorAssemblyLegStands.cs" id="7_y435x"]
 [ext_resource type="Material" uid="uid://bhsy5iqi7rvp" path="res://assets/3DModels/Materials/LegsStandMaterial.tres" id="8_64v37"]
 [ext_resource type="Shader" uid="uid://b6uso6bqiurpv" path="res://assets/3DModels/Shaders/MetalShaderLegsBar.tres" id="11_0gvht"]
 
@@ -275,7 +276,7 @@ Length = 4.0
 
 [node name="LegStands" type="Node3D" parent="."]
 transform = Transform3D(0.25, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
-script = ExtResource("3_uu1p1")
+script = ExtResource("7_y435x")
 
 [node name="AutoLegsStandFront" parent="LegStands" instance=ExtResource("2_a0feq")]
 transform = Transform3D(1, 0, 0, 0, 1.618, 0, 0, 0, 1.055, -1.8, 0, 0)

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -43,7 +43,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 * If both happen at the same time, the property wins.
 	 */
 	private void SyncConveyorsAngle() {
-		Basis scale = Basis.Identity.Scaled(this.Basis.Scale);
+		Basis scale = Basis.Identity.Scaled(_cachedScale);
 		Basis scalePrev = Basis.Identity.Scaled(transformPrev.Basis.Scale);
 		if (ConveyorAngle != conveyorAnglePrev) {
 			Basis targetRot = new Basis(new Vector3(0, 0, 1), ConveyorAngle);
@@ -73,11 +73,11 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 */
 	private float GetConveyorLineLength() {
 		if (conveyors == null) {
-			return this.Scale.X;
+			return Length;
 		}
 		if (ConveyorAutomaticLength) {
 			var cos = Mathf.Cos(conveyors.Basis.GetEuler().Z);
-			return this.Scale.X * 1 / (Mathf.Abs(cos) >= 0.01f ? cos : 0.01f);
+			return Length / (Mathf.Abs(cos) >= 0.01f ? cos : 0.01f);
 		}
 		// Add up the length of all conveyors.
 		// Assume all conveyors are aligned end-to-end.
@@ -117,10 +117,10 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	protected virtual void ScaleConveyor(Node3D conveyor, float conveyorLength) {
 		Vector3 newScale;
 		if (ConveyorAutomaticLength) {
-			newScale = new Vector3(conveyorLength, 1f, this.Scale.Z);
+			newScale = new Vector3(conveyorLength, 1f, Width / 2f);
 		} else {
 			// Always scale width.
-			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, this.Scale.Z);
+			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, Width / 2f);
 		}
 		if (conveyor.Scale != newScale) {
 			conveyor.Scale = newScale;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -133,7 +133,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		}
 	}
 
-	private static bool IsConveyor(Node node) {
+	internal static bool IsConveyor(Node node) {
 		return node as IConveyor != null || node as IBeltConveyor != null || node as IRollerConveyor != null;
 	}
 

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Collections.Generic;
 
-public partial class ConveyorAssembly : Node3D
+public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region Conveyors
 	#region Conveyors / Update "Conveyors" node

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region Conveyors
+	protected virtual float ConveyorBaseLength => 1f;
+	protected virtual float ConveyorBaseWidth => 2f;
+
 	#region Conveyors / Update "Conveyors" node
 	private void UpdateConveyors()
 	{
@@ -117,10 +120,10 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	protected virtual void ScaleConveyor(Node3D conveyor, float conveyorLength) {
 		Vector3 newScale;
 		if (ConveyorAutomaticLength) {
-			newScale = new Vector3(conveyorLength, 1f, Width / 2f);
+			newScale = new Vector3(conveyorLength / ConveyorBaseLength, 1f, Width / ConveyorBaseWidth);
 		} else {
 			// Always scale width.
-			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, Width / 2f);
+			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, Width / ConveyorBaseWidth);
 		}
 		if (conveyor.Scale != newScale) {
 			conveyor.Scale = newScale;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -38,6 +38,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		_cachedConveyorsBasis = _cachedConveyorsTransform.Basis;
 		_cachedConveyorsRotation = _cachedConveyorsBasis.GetEuler();
 
+		BasisChanged += void (_) => conveyors.SetNeedsUpdate(true);
+		conveyors.BasisChanged += void (_) => conveyors.SetNeedsUpdate(true);
 		conveyors.TransformChanged += void (_) => UpdateSides();
 
 		ConveyorAngle = _conveyorAngle;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -14,6 +14,9 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	private Basis _cachedConveyorsBasis = Basis.Identity;
 	private Vector3 _cachedConveyorsRotation = Vector3.Zero;
 
+	private float conveyorLineLength = 0f;
+	private float conveyorLineWidth = 0f;
+
 	// This will become the constructor once this file is converted into its own class.
 	private void SetupConveyors()
 	{
@@ -38,9 +41,23 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 
 		LockConveyorsGroup();
 		SyncConveyorsAngle();
-		var conveyorLineLength = GetConveyorLineLength();
-		var conveyorLineWidth = GetConveyorLineWidth();
-		ScaleConveyorLine(conveyors, conveyorLineLength, conveyorLineWidth);
+
+		float conveyorLineLengthPrev = conveyorLineLength;
+		conveyorLineLength = GetConveyorLineLength();
+		bool conveyorLineLengthChanged = conveyorLineLengthPrev != conveyorLineLength;
+
+		float conveyorLineWidthPrev = conveyorLineWidth;
+		conveyorLineWidth = GetConveyorLineWidth();
+		bool conveyorLineWidthChanged = conveyorLineWidthPrev != conveyorLineWidth;
+
+		// Assume no children added or removed, which we would also need to account for.
+		bool conveyorScaleNeedsUpdate = conveyorLineLengthChanged || conveyorLineWidthChanged;
+		if (conveyorScaleNeedsUpdate)
+		{
+			ScaleConveyorLine(conveyors, conveyorLineLength, conveyorLineWidth);
+			if (IsInstanceValid(legStands)) legStands.UpdateLegStandCoverage();
+		}
+
 	}
 
 	protected virtual void LockConveyorsGroup() {

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -44,13 +44,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	}
 
 	#region Conveyors / Update "Conveyors" node
-	private void UpdateConveyors()
+	internal void UpdateConveyors()
 	{
-		if (conveyors == null)
-		{
-			return;
-		}
-
 		float conveyorLineLengthPrev = conveyorLineLength;
 		conveyorLineLength = GetConveyorLineLength();
 		bool conveyorLineLengthChanged = conveyorLineLengthPrev != conveyorLineLength;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -47,7 +47,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 */
 	private void SyncConveyorsAngle() {
 		Basis scale = Basis.Identity.Scaled(_cachedScale);
-		Basis scalePrev = Basis.Identity.Scaled(transformPrev.Basis.Scale);
+		Basis scalePrev = Basis.Identity.Scaled(_scalePrev);
 		if (ConveyorAngle != conveyorAnglePrev) {
 			Basis targetRot = new Basis(new Vector3(0, 0, 1), ConveyorAngle);
 			conveyors.Basis = scale.Inverse() * targetRot;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -49,7 +49,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			return;
 		}
 
-		LockConveyorsGroup();
 		SyncConveyorsAngle();
 
 		float conveyorLineLengthPrev = conveyorLineLength;
@@ -81,7 +80,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		conveyors.Transform = newTransform;
 	}
 
-	protected virtual Transform3D LockConveyorsGroup(Transform3D transform) {
+	internal virtual Transform3D LockConveyorsGroup(Transform3D transform) {
 		// Lock Z position
 		Vector3 newPos = new Vector3(transform.Origin.X, transform.Origin.Y, 0f);
 		transform.Origin = newPos;
@@ -89,8 +88,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		var (eulerX, eulerY, eulerZ) = transform.Basis.GetEuler();
 		if (eulerX != 0 || eulerY != 0) {
 			Vector3 newRot = new Vector3(0f, 0f, eulerZ);
-			var scale = transform.Basis.Scale;
-			var basis = Basis.FromEuler(newRot).Scaled(scale);
+			var basis = Basis.FromEuler(newRot);
 			transform = new Transform3D(basis, newPos);
 		}
 		return transform;

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -28,7 +28,15 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			_cachedConveyorsRotation = _cachedConveyorsBasis.GetEuler();
 		};
 		// Ensure cached values are up to date
-		conveyors.SetTransform(conveyors.Transform);
+		//conveyors.SetTransform(conveyors.Transform);
+		// The above commented line doesn't work, but should work once this is turned into a constructor.
+		// The problem is OnTransformSet skips emitting all the on-change signals because it determines there is no change.
+		// In a constructor, we would be guaranteed to be the the first caller of OnTransformSet.
+		// In the meantime, set cache fields manually as a workaround.
+		_cachedConveyorsTransform = conveyors.Transform;
+		_cachedConveyorsPosition = _cachedConveyorsTransform.Origin;
+		_cachedConveyorsBasis = _cachedConveyorsTransform.Basis;
+		_cachedConveyorsRotation = _cachedConveyorsBasis.GetEuler();
 
 		conveyors.TransformChanged += void (_) => UpdateSides();
 	}

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -65,7 +65,12 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		if (conveyorScaleNeedsUpdate)
 		{
 			ScaleConveyorLine(conveyors, conveyorLineLength, conveyorLineWidth);
+
+			// While we're here, let's update the things that depend on conveyors's children's Transforms.
+			// UpdateLegStandCoverage depends on the extents of conveyor's children.
 			legStands?.UpdateLegStandCoverage();
+			// UpdateSide depends on conveyorLineLength, though it actually measures it from first conveyor child's Scale.X.
+			UpdateSides();
 		}
 
 	}

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -55,7 +55,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		if (conveyorScaleNeedsUpdate)
 		{
 			ScaleConveyorLine(conveyors, conveyorLineLength, conveyorLineWidth);
-			if (IsInstanceValid(legStands)) legStands.UpdateLegStandCoverage();
+			legStands?.UpdateLegStandCoverage();
 		}
 
 	}

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -75,20 +75,25 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 
 	}
 
-	protected virtual void LockConveyorsGroup() {
+	private void LockConveyorsGroup() {
+		var newTransform = LockConveyorsGroup(conveyors.Transform);
+		if (newTransform == conveyors.Transform) return;
+		conveyors.Transform = newTransform;
+	}
+
+	protected virtual Transform3D LockConveyorsGroup(Transform3D transform) {
 		// Lock Z position
-		Vector3 newPos = new Vector3(_cachedConveyorsPosition.X, _cachedConveyorsPosition.Y, 0f);
-		if (_cachedConveyorsPosition != newPos) {
-			conveyors.Position = newPos;
-		}
+		Vector3 newPos = new Vector3(transform.Origin.X, transform.Origin.Y, 0f);
+		transform.Origin = newPos;
 		// Lock X and Y rotation
-		if (_cachedConveyorsRotation.X > 0.001f || _cachedConveyorsRotation.X < -0.001f || _cachedConveyorsRotation.Y > 0.001f || _cachedConveyorsRotation.Y < -0.001) {
-			// This seems to mess up scale, but at least that's fixed on the next frame.
-			Vector3 newRot = new Vector3(0f, 0f, _cachedConveyorsRotation.Z);
-			if (_cachedConveyorsRotation != newRot) {
-				conveyors.Rotation = newRot;
-			}
+		var (eulerX, eulerY, eulerZ) = transform.Basis.GetEuler();
+		if (eulerX != 0 || eulerY != 0) {
+			Vector3 newRot = new Vector3(0f, 0f, eulerZ);
+			var scale = transform.Basis.Scale;
+			var basis = Basis.FromEuler(newRot).Scaled(scale);
+			transform = new Transform3D(basis, newPos);
 		}
+		return transform;
 	}
 
 	/**

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -39,6 +39,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		_cachedConveyorsRotation = _cachedConveyorsBasis.GetEuler();
 
 		conveyors.TransformChanged += void (_) => UpdateSides();
+
+		ConveyorAngle = _conveyorAngle;
 	}
 
 	#region Conveyors / Update "Conveyors" node
@@ -48,8 +50,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		{
 			return;
 		}
-
-		SyncConveyorsAngle();
 
 		float conveyorLineLengthPrev = conveyorLineLength;
 		conveyorLineLength = GetConveyorLineLength();
@@ -92,30 +92,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			transform = new Transform3D(basis, newPos);
 		}
 		return transform;
-	}
-
-	/**
-	 * Synchronize the angle of the conveyors with the assembly's ConveyorAngle property.
-	 *
-	 * If the property changes, the conveyors are rotated to match.
-	 * If the conveyors are rotated manually, the property is updated.
-	 * If both happen at the same time, the property wins.
-	 */
-	private void SyncConveyorsAngle() {
-		Basis scale = Basis.Identity.Scaled(_cachedScale);
-		Basis scalePrev = Basis.Identity.Scaled(_scalePrev);
-		if (ConveyorAngle != conveyorAnglePrev) {
-			Basis targetRot = new Basis(new Vector3(0, 0, 1), ConveyorAngle);
-			conveyors.Basis = scale.Inverse() * targetRot;
-		} else {
-			float angle = (scale * _cachedConveyorsBasis).GetEuler().Z;
-			float anglePrev = (scalePrev * conveyorsTransformPrev.Basis).GetEuler().Z;
-			double angleDelta = Mathf.Abs(angle - anglePrev) % (2 * Math.PI);
-			if (angleDelta > Math.PI / 360.0) {
-				this.ConveyorAngle = (scale * _cachedConveyorsBasis).GetEuler().Z;
-				NotifyPropertyListChanged();
-			}
-		};
 	}
 	#endregion Conveyors / Update "Conveyors" node
 

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -29,6 +29,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		};
 		// Ensure cached values are up to date
 		conveyors.SetTransform(conveyors.Transform);
+
+		conveyors.TransformChanged += void (_) => UpdateSides();
 	}
 
 	#region Conveyors / Update "Conveyors" node

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -39,7 +39,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		LockConveyorsGroup();
 		SyncConveyorsAngle();
 		var conveyorLineLength = GetConveyorLineLength();
-		ScaleConveyorLine(conveyors, conveyorLineLength);
+		var conveyorLineWidth = GetConveyorLineWidth();
+		ScaleConveyorLine(conveyors, conveyorLineLength, conveyorLineWidth);
 	}
 
 	protected virtual void LockConveyorsGroup() {
@@ -94,6 +95,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 *
 	 * @return The length of the conveyor line along its x-axis.
 	 */
+	// TODO override in CurvedConveyorAssembly
 	private float GetConveyorLineLength() {
 		if (conveyors == null) {
 			return Length;
@@ -115,20 +117,25 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		return sum;
 	}
 
+	private float GetConveyorLineWidth() {
+		return Width;
+	}
+
 	/**
 	 * Scale all conveyor children of a given node.
 	 *
 	 * This would be a great place to implement proportional scaling and positioning of the conveyors,
-	 * but currently, we just scale every conveyor to the length of the whole line and leave its position alone.
+	 * but currently, we just scale every conveyor to the length and width of the whole line and leave its position alone.
 	 *
 	 * @param conveyorLine The parent of the conveyors.
 	 * @param conveyorLineLength The length of the conveyor line to scale to. Ignored if ConveyorAutomaticLength is false.
+	 * @param conveyorLineWidth The width of the conveyor line to scale to.
 	 */
-	private void ScaleConveyorLine(Node3D conveyorLine, float conveyorLineLength) {
+	private void ScaleConveyorLine(Node3D conveyorLine, float conveyorLineLength, float conveyorLineWidth) {
 		foreach (Node child in conveyorLine.GetChildren()) {
 			Node3D child3d = child as Node3D;
 			if (IsConveyor(child3d)) {
-				ScaleConveyor(child3d, conveyorLineLength);
+				ScaleConveyor(child3d, conveyorLineLength, conveyorLineWidth);
 			}
 		}
 	}
@@ -137,13 +144,13 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		return node as IConveyor != null || node as IBeltConveyor != null || node as IRollerConveyor != null;
 	}
 
-	protected virtual void ScaleConveyor(Node3D conveyor, float conveyorLength) {
+	protected virtual void ScaleConveyor(Node3D conveyor, float conveyorLength, float conveyorWidth) {
 		Vector3 newScale;
 		if (ConveyorAutomaticLength) {
-			newScale = new Vector3(conveyorLength / ConveyorBaseLength, 1f, Width / ConveyorBaseWidth);
+			newScale = new Vector3(conveyorLength / ConveyorBaseLength, 1f, conveyorWidth / ConveyorBaseWidth);
 		} else {
 			// Always scale width.
-			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, Width / ConveyorBaseWidth);
+			newScale = new Vector3(conveyor.Scale.X, conveyor.Scale.Y, conveyorWidth / ConveyorBaseWidth);
 		}
 		if (conveyor.Scale != newScale) {
 			conveyor.Scale = newScale;

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -113,7 +113,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 * This currently shouldn't do anything for curved assemblies.
 	 */
 	private void SyncLegStandsOffsets() {
-		Basis assemblyScale = Basis.Identity.Scaled(this.Basis.Scale);
+		Basis assemblyScale = Basis.Identity.Scaled(_cachedScale);
 		Basis assemblyScalePrev = Basis.Identity.Scaled(transformPrev.Basis.Scale);
 		Vector3 legStandsScaledPosition = assemblyScale * legStands.Position;
 		Vector3 legStandsScaledPositionPrev = assemblyScalePrev * legStandsTransformPrev.Origin;
@@ -180,7 +180,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 				continue;
 			}
 			SnapToLegStandsPath(legStand);
-			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth);
+			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / 2f);
 		}
 
 	}
@@ -196,12 +196,12 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 		}
 		// This is a hack to account for the fact that CurvedRollerConveyors are slightly wider than other conveyors.
 		if (firstConveyor is CurvedRollerConveyor) {
-			return this.Scale.Z * 1.055f;
+			return Width * 1.055f;
 		}
 		if (firstConveyor is RollerConveyor) {
-			return this.Scale.Z + 0.051f;
+			return Width + 0.051f * 2f;
 		}
-		return this.Scale.Z;
+		return Width;
 	}
 
 	/**

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -255,8 +255,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 * @param legStand The leg stand to move.
 	 * @param position The path position to move the leg stand to.
 	 */
-	protected virtual void MoveLegStandToPathPosition(Node3D legStand, float position) {
-		Vector3 newPosition = new Vector3(position, legStand.Position.Y, 0f);
+	protected virtual void MoveLegStandToPathPosition(Node3D legStand, float pathPosition) {
+		Vector3 newPosition = new Vector3(pathPosition, legStand.Position.Y, 0f);
 		if (legStand.Position != newPosition)
 		{
 			legStand.Position = newPosition;

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -34,7 +34,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			Node3D conveyor = child as Node3D;
 			if (IsConveyor(conveyor)) {
 				// Conveyor's Transform in the legStands space.
-				Transform3D localConveyorTransform = legStands.Transform.AffineInverse() * conveyors.Transform * conveyor.Transform;
+				Transform3D localConveyorTransform = legStands.Transform.AffineInverse() * _cachedConveyorsTransform * conveyor.Transform;
 
 				// Extent and offset positions in unscaled conveyor space
 				Vector3 conveyorExtentFront = new Vector3(-Mathf.Abs(localConveyorTransform.Basis.Scale.X * 0.5f), 0f, 0f);
@@ -104,12 +104,12 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	protected virtual void LockLegStandsGroup() {
 		// Always align LegStands group with Conveyors group.
 		if (conveyors != null) {
-			Vector3 newPos = new Vector3(legStands.Position.X, legStands.Position.Y, conveyors.Position.Z);
+			Vector3 newPos = new Vector3(legStands.Position.X, legStands.Position.Y, _cachedConveyorsPosition.Z);
 			if (legStands.Position != newPos) {
 				legStands.Position = newPos;
 			}
 			// Conveyors can't rotate anymore, so this doesn't do much.
-			Vector3 newRot = new Vector3(0f, conveyors.Rotation.Y, 0f);
+			Vector3 newRot = new Vector3(0f, _cachedConveyorsRotation.Y, 0f);
 			if (legStands.Rotation != newRot) {
 				legStands.Rotation = newRot;
 			}
@@ -467,7 +467,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			return;
 		}
 		// Plane transformed from conveyors space into legStands space.
-		Plane conveyorPlane = new Plane(Vector3.Up, new Vector3(0f, -AutoLegStandsModelGrabsOffset, 0f)) * conveyors.Transform.AffineInverse() * legStands.Transform;
+		Plane conveyorPlane = new Plane(Vector3.Up, new Vector3(0f, -AutoLegStandsModelGrabsOffset, 0f)) * _cachedConveyorsTransform.AffineInverse() * legStands.Transform;
 		Vector3 conveyorPlaneGlobalNormal = conveyorPlane.Normal * legStands.GlobalBasis.Inverse();
 
 		foreach (Node child in legStands.GetChildren()) {

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -127,7 +127,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	 */
 	private void SyncLegStandsOffsets() {
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedScale);
-		Basis assemblyScalePrev = Basis.Identity.Scaled(transformPrev.Basis.Scale);
+		Basis assemblyScalePrev = Basis.Identity.Scaled(_scalePrev);
 		Vector3 legStandsScaledPosition = assemblyScale * legStands.Position;
 		Vector3 legStandsScaledPositionPrev = assemblyScalePrev * legStandsTransformPrev.Origin;
 

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -5,6 +5,15 @@ using System.Diagnostics;
 public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region Leg Stands
+	#region Leg Stands / Constants
+	private const string AUTO_LEG_STAND_NAME_PREFIX = "AutoLegsStand";
+	private const string AUTO_LEG_STAND_NAME_FRONT = "AutoLegsStandFront";
+	private const string AUTO_LEG_STAND_NAME_REAR = "AutoLegsStandRear";
+       private const int LEG_INDEX_FRONT = -1;
+       private const int LEG_INDEX_REAR = -2;
+       private const int LEG_INDEX_NON_AUTO = -3;
+	#endregion Leg Stands / Constants
+
 	#region Leg Stands / Conveyor coverage extents
 	private void UpdateLegStandCoverage() {
 		(legStandCoverageMinPrev, legStandCoverageMaxPrev) = (legStandCoverageMin, legStandCoverageMax);

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Diagnostics;
 
-public partial class ConveyorAssembly : Node3D
+public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region Leg Stands
 	#region Leg Stands / Conveyor coverage extents

--- a/src/Assembly/ConveyorAssembly.LegStands.cs
+++ b/src/Assembly/ConveyorAssembly.LegStands.cs
@@ -6,6 +6,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region Leg Stands
 	#region Leg Stands / Constants
+	private const float LegStandsBaseWidth = 2f;
 	private const string AUTO_LEG_STAND_NAME_PREFIX = "AutoLegsStand";
 	private const string AUTO_LEG_STAND_NAME_FRONT = "AutoLegsStandFront";
 	private const string AUTO_LEG_STAND_NAME_REAR = "AutoLegsStandRear";
@@ -192,7 +193,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 				continue;
 			}
 			SnapToLegStandsPath(legStand);
-			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / 2f);
+			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / LegStandsBaseWidth);
 		}
 
 	}

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -39,8 +39,10 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	protected virtual void LockSidePosition(Node3D side, bool isRight) {
 		// Sides always snap onto the conveyor line
 		side.Transform = conveyors.Transform;
-		var offsetZ = (isRight? 1 : -1) * side.Basis.Z * (Width / 2f - 1f);
-		side.Position += offsetZ;
+		float offsetDistance = Width / 2f - 1f;
+		Vector3 offsetDirection = (isRight ? 1 : -1) * side.Basis.Z;
+		Vector3 offset = offsetDirection * offsetDistance;
+		side.Position += offset;
 	}
 	#endregion SideGuards / Update "LeftSide" and "RightSide" nodes
 

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -19,14 +19,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 
 
 	private void UpdateSide(bool isRight) {
-		Node3D side;
-		if (isRight) {
-			rightSide = IsInstanceValid(rightSide) ? rightSide : GetNodeOrNull<Node3D>("RightSide");
-			side = rightSide;
-		} else {
-			leftSide = IsInstanceValid(leftSide) ? leftSide : GetNodeOrNull<Node3D>("LeftSide");
-			side = leftSide;
-		}
+		Node3D side = isRight ? rightSide : leftSide;
 		if (side == null) {
 			return;
 		}

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -6,6 +6,10 @@ using Godot;
 public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region SideGuards
+	#region SideGuards / Constants
+	private const string AUTO_SIDE_GUARD_NAME_PREFIX = "AutoSideGuard";
+	#endregion SideGuards / Constants
+
 	#region SideGuards / Update "LeftSide" and "RightSide" nodes
 	private void UpdateSides()
 	{

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -24,6 +24,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 			return;
 		}
 		if (conveyors != null) {
+			// TODO: Connect to conveyors.TransformChanged and remove from here.
 			LockSidePosition(side, isRight);
 		}
 		UpdateAutoSideGuards(side, isRight);

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -35,7 +35,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	protected virtual void LockSidePosition(Node3D side, bool isRight) {
 		// Sides always snap onto the conveyor line
 		side.Transform = conveyors.Transform;
-		var offsetZ = (isRight? 1 : -1) * side.Basis.Z * (this.Scale.Z - 1f);
+		var offsetZ = (isRight? 1 : -1) * side.Basis.Z * (Width / 2f - 1f);
 		side.Position += offsetZ;
 	}
 	#endregion SideGuards / Update "LeftSide" and "RightSide" nodes

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Godot;
 
-public partial class ConveyorAssembly : Node3D
+public partial class ConveyorAssembly : TransformMonitoredNode3D
 {
 	#region SideGuards
 	#region SideGuards / Update "LeftSide" and "RightSide" nodes

--- a/src/Assembly/ConveyorAssembly.SideGuards.cs
+++ b/src/Assembly/ConveyorAssembly.SideGuards.cs
@@ -31,7 +31,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 
 	protected virtual void LockSidePosition(Node3D side, bool isRight) {
 		// Sides always snap onto the conveyor line
-		side.Transform = conveyors.Transform;
+		side.Transform = _cachedConveyorsTransform;
 		float offsetDistance = Width / 2f - 1f;
 		Vector3 offsetDirection = (isRight ? 1 : -1) * side.Basis.Z;
 		Vector3 offset = offsetDirection * offsetDistance;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -716,8 +716,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	 * @param child The child node to prevent scaling.
 	 */
 	private void PreventChildScaling(Node3D child) {
-		var basisRotation = this.Transform.Basis.Orthonormalized();
-		var basisScale = basisRotation.Inverse() * this.Transform.Basis;
+		var basisRotation = _cachedBasis.Orthonormalized();
+		var basisScale = basisRotation.Inverse() * _cachedBasis;
 		var xformScaleInverse = new Transform3D(basisScale, new Vector3(0, 0, 0)).AffineInverse();
 
 		var basisRotationPrev = transformPrev.Basis.Orthonormalized();

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -59,7 +59,17 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private float _conveyorAngle = 0f;
 
 	[Export]
-	public bool ConveyorAutomaticLength { get; set; } = true;
+	public bool ConveyorAutomaticLength
+	{
+		get => _conveyorAutomaticLength;
+		set
+		{
+			if (value == _conveyorAutomaticLength) return;
+			_conveyorAutomaticLength = value;
+			conveyors?.SetNeedsUpdate(true);
+		}
+	}
+	private bool _conveyorAutomaticLength = true;
 
 	// This rest of this section is for properties proxied to the conveyor parts.
 	[ExportSubgroup("Comms")]

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -656,9 +656,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		has_processed_at_least_once = true;
 
 		UpdateConveyors();
-		if (conveyorsTransformPrev != _cachedConveyorsTransform) {
-			UpdateSides();
-		}
 
 		_scalePrev = _cachedBasis.Scale;
 		conveyorAnglePrev = ConveyorAngle;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -704,8 +704,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	}
 
 	internal Transform3D PreventChildScaling(Transform3D childTransform, Basis basisPrev) {
-		var basisRotation = _cachedBasis.Orthonormalized();
-		var basisScale = basisRotation.Inverse() * _cachedBasis;
+		var basisRotation = Basis.Orthonormalized();
+		var basisScale = basisRotation.Inverse() * Basis;
 		var xformScaleInverse = new Transform3D(basisScale, new Vector3(0, 0, 0)).AffineInverse();
 
 		var basisRotationPrev = basisPrev.Orthonormalized();

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -14,25 +14,14 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#region Fields
 	#region Fields / Nodes
 	private Root main;
-	protected Node3D conveyors
-	{
-		get
-		{
-			if (!IsInstanceValid(_conveyors))
-			{
-				_conveyors = GetNodeOrNull<Node3D>("Conveyors");
-			}
-			return _conveyors;
-		}
-		set
-		{
-			_conveyors = value;
-		}
-	}
+	protected Node3D conveyors => IsInstanceValid(_conveyors) ? _conveyors : _conveyors = GetNodeOrNull<Node3D>("Conveyors");
 	private Node3D _conveyors;
-	private Node3D rightSide;
-	private Node3D leftSide;
-	protected Node3D legStands;
+	private Node3D rightSide => IsInstanceValid(_rightSide) ? _rightSide : _rightSide = GetNodeOrNull<Node3D>("RightSide");
+	private Node3D _rightSide;
+	private Node3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<Node3D>("LeftSide");
+	private Node3D _leftSide;
+	protected Node3D legStands => IsInstanceValid(_legStands) ? _legStands : _legStands = GetNodeOrNull<Node3D>("LegStands");
+	private Node3D _legStands;
 	#endregion Fields / Nodes
 	private Transform3D conveyorsTransformPrev;
 	private Transform3D legStandsTransformPrev;
@@ -621,8 +610,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	public override void _Ready()
 	{
 		main = GetTree().EditedSceneRoot as Root;
-		conveyors = GetNode<Node3D>("Conveyors");
-		legStands = GetNodeOrNull<Node3D>("LegStands");
 
 		_basisPrev = _cachedBasis;
 		_scalePrev = _basisPrev.Scale;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -614,6 +614,9 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		ScaleXChanged += SetLength;
 		ScaleZChanged += void (value) => SetWidth(value * 2f);
 		ScaleYChanged += void (value) => SetHeight(value * 2f);
+
+		// If necessary, trigger signals to set new values
+		SetTransform(Transform);
 	}
 
 	public override void _Ready()

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -457,6 +457,28 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private float legStandCoverageMaxPrev;
 	#endregion Fields / Leg stand coverage
 
+	#region Fields / Length, Width, and Height
+	private Vector3 _cachedScale => Scale;
+
+	public float Length
+	{
+		get => Scale.X;
+		set => Scale = new Vector3(value, Scale.Y, Scale.Z);
+	}
+
+	public float Width
+	{
+		get => Scale.Z * 2f;
+		set => Scale = new Vector3(Scale.X, Scale.Y, value / 2f);
+	}
+
+	public float Height
+	{
+		get => Scale.Y * 2f;
+		set => Scale = new Vector3(Scale.X, value / 2f, Scale.Z);
+	}
+	#endregion Fields / Length, Width, and Height
+
 	// This variable is used to store the names of the pre-existing leg stands that can't be owned by the edited scene.
 	private Dictionary <StringName, Node> foreignLegStandsOwners = new();
 

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -5,21 +5,6 @@ using System.Linq;
 [Tool]
 public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 {
-	#region Constants
-	#region Constants / Leg Stands
-	private const string AUTO_LEG_STAND_NAME_PREFIX = "AutoLegsStand";
-	private const string AUTO_LEG_STAND_NAME_FRONT = "AutoLegsStandFront";
-	private const string AUTO_LEG_STAND_NAME_REAR = "AutoLegsStandRear";
-	private const int LEG_INDEX_FRONT = -1;
-	private const int LEG_INDEX_REAR = -2;
-	private const int LEG_INDEX_NON_AUTO = -3;
-	#endregion Constants / Leg Stands
-
-	#region Constants / Side Guards
-	private const string AUTO_SIDE_GUARD_NAME_PREFIX = "AutoSideGuard";
-	#endregion Constants / Side Guards
-	#endregion Constants
-
 	#region Fields
 	#region Fields / Nodes
 	private Root main;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -14,14 +14,28 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#region Fields
 	#region Fields / Nodes
 	private Root main;
-	protected Node3D conveyors => IsInstanceValid(_conveyors) ? _conveyors : _conveyors = GetNodeOrNull<Node3D>("Conveyors");
-	private Node3D _conveyors;
-	private Node3D rightSide => IsInstanceValid(_rightSide) ? _rightSide : _rightSide = GetNodeOrNull<Node3D>("RightSide");
-	private Node3D _rightSide;
-	private Node3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<Node3D>("LeftSide");
-	private Node3D _leftSide;
-	protected Node3D legStands => IsInstanceValid(_legStands) ? _legStands : _legStands = GetNodeOrNull<Node3D>("LegStands");
-	private Node3D _legStands;
+	protected TransformMonitoredNode3D conveyors
+	{
+		get
+		{
+			if (!IsInstanceValid(_conveyors))
+			{
+				_conveyors = GetNodeOrNull<TransformMonitoredNode3D>("Conveyors");
+				if (IsInstanceValid(_conveyors))
+				{
+					SetupConveyors();
+				}
+			}
+			return _conveyors;
+		}
+	}
+	private TransformMonitoredNode3D _conveyors;
+	private TransformMonitoredNode3D rightSide => IsInstanceValid(_rightSide) ? _rightSide : _rightSide = GetNodeOrNull<TransformMonitoredNode3D>("RightSide");
+	private TransformMonitoredNode3D _rightSide;
+	private TransformMonitoredNode3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<TransformMonitoredNode3D>("LeftSide");
+	private TransformMonitoredNode3D _leftSide;
+	protected TransformMonitoredNode3D legStands => IsInstanceValid(_legStands) ? _legStands : _legStands = GetNodeOrNull<TransformMonitoredNode3D>("LegStands");
+	private TransformMonitoredNode3D _legStands;
 	#endregion Fields / Nodes
 	private Transform3D conveyorsTransformPrev;
 	private Transform3D legStandsTransformPrev;
@@ -617,12 +631,12 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		// Apply the ConveyorsAngle property if needed.
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedScale);
 		if (conveyors != null) {
-			float conveyorsStartingAngle = (assemblyScale * conveyors.Basis).GetEuler().Z;
+			float conveyorsStartingAngle = (assemblyScale * _cachedConveyorsBasis).GetEuler().Z;
 			conveyorAnglePrev = conveyorsStartingAngle;
-			conveyorsTransformPrev = conveyors.Transform;
+			conveyorsTransformPrev = _cachedConveyorsTransform;
 			SyncConveyorsAngle();
 			conveyorAnglePrev = ConveyorAngle;
-			conveyorsTransformPrev = conveyors.Transform;
+			conveyorsTransformPrev = _cachedConveyorsTransform;
 		}
 
 		// Apply the AutoLegStandsFloorOffset and AutoLegStandsIntervalLegsOffset properties if needed.
@@ -662,7 +676,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 		PreventAllChildScaling();
 		UpdateConveyors();
-		if (conveyorsTransformPrev != conveyors.Transform) {
+		if (conveyorsTransformPrev != _cachedConveyorsTransform) {
 			UpdateSides();
 		}
 		UpdateLegStandCoverage();
@@ -670,7 +684,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		_basisPrev = _cachedBasis;
 		_scalePrev = _basisPrev.Scale;
 		conveyorAnglePrev = ConveyorAngle;
-		conveyorsTransformPrev = conveyors.Transform;
+		conveyorsTransformPrev = _cachedConveyorsTransform;
 		autoLegStandsIntervalLegsEnabledPrev = AutoLegStandsIntervalLegsEnabled;
 		autoLegStandsEndLegFrontPrev = AutoLegStandsEndLegFront;
 		autoLegStandsEndLegRearPrev = AutoLegStandsEndLegRear;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -400,7 +400,16 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 	[ExportGroup("Leg Stands", "AutoLegStands")]
 	[Export(PropertyHint.None, "suffix:m")]
-	public float AutoLegStandsFloorOffset = 0f;
+	public float AutoLegStandsFloorOffset {
+		get => _autoLegStandsFloorOffset;
+		set
+		{
+			if (_autoLegStandsFloorOffset == value) return;
+			_autoLegStandsFloorOffset = value;
+			legStands?.SyncLegStandsOffsets();
+		}
+	}
+	private float _autoLegStandsFloorOffset = 0f;
 
 	[ExportSubgroup("Interval Legs", "AutoLegStandsIntervalLegs")]
 	[Export]
@@ -410,7 +419,16 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	public float AutoLegStandsIntervalLegsInterval { get; set; } = 2f;
 
 	[Export(PropertyHint.Range, "-5,5,or_less,or_greater,suffix:m")]
-	public float AutoLegStandsIntervalLegsOffset { get; set; } = 0f;
+	public float AutoLegStandsIntervalLegsOffset {
+		get => _autoLegStandsIntervalLegsOffset;
+		set
+		{
+			if (_autoLegStandsIntervalLegsOffset == value) return;
+			_autoLegStandsIntervalLegsOffset = value;
+			legStands?.SyncLegStandsOffsets();
+		}
+	}
+	private float _autoLegStandsIntervalLegsOffset = 0f;
 
 	[ExportSubgroup("End Legs", "AutoLegStandsEndLeg")]
 	[Export]

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -618,6 +618,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		Height = BaseHeight;
 		// If necessary, trigger signals to set new values
 		SetTransform(Transform);
+
+		TransformChanged += void (_) => PreventAllChildScaling();
 	}
 
 	public override void _Ready()
@@ -639,6 +641,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		}
 
 		UpdateSides();
+
+		PreventAllChildScaling();
 	}
 
 	bool has_processed_at_least_once = false;
@@ -651,7 +655,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		if (IsSimulationRunning() && has_processed_at_least_once) return;
 		has_processed_at_least_once = true;
 
-		PreventAllChildScaling();
 		UpdateConveyors();
 		if (conveyorsTransformPrev != _cachedConveyorsTransform) {
 			UpdateSides();

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -450,7 +450,18 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 	[ExportSubgroup("Leg Model", "AutoLegStandsModel")]
 	[Export(PropertyHint.None, "suffix:m")]
-	public float AutoLegStandsModelGrabsOffset = 0.382f;
+	public float AutoLegStandsModelGrabsOffset {
+		get => _autoLegStandsModelGrabsOffset;
+		set
+		{
+			_autoLegStandsModelGrabsOffset = value;
+			if (IsInstanceValid(legStands))
+			{
+				UpdateLegStandsHeightAndVisibility();
+			}
+		}
+	}
+	private float _autoLegStandsModelGrabsOffset = 0.382f;
 
 	[Export]
 	public PackedScene AutoLegStandsModelScene = GD.Load<PackedScene>("res://parts/ConveyorLegBC.tscn");

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -458,9 +458,9 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#endregion Fields / Leg stand coverage
 
 	#region Fields / Length, Width, and Height
-	private Vector3 _cachedScale;
+	private Vector3 _cachedScale = Vector3.One;
 
-	private float _length;
+	private float _length = 1f;
 	public float Length
 	{
 		get => _length;
@@ -473,7 +473,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		_length = length;
 	}
 
-	private float _width;
+	private float _width = 2f;
 	public float Width
 	{
 		get => _width;
@@ -486,7 +486,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		_width = width;
 	}
 
-	private float _height;
+	private float _height = 2f;
 	public float Height
 	{
 		get => _height;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 [Tool]
-public partial class ConveyorAssembly : Node3D, IComms
+public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 {
 	#region Constants
 	#region Constants / Leg Stands
@@ -43,7 +43,7 @@ public partial class ConveyorAssembly : Node3D, IComms
 	private Node3D leftSide;
 	protected Node3D legStands;
 	#endregion Fields / Nodes
-	protected Transform3D transformPrev;
+	private Transform3D transformPrev;
 	private Transform3D conveyorsTransformPrev;
 	private Transform3D legStandsTransformPrev;
 
@@ -619,7 +619,6 @@ public partial class ConveyorAssembly : Node3D, IComms
 		if (IsSimulationRunning() && has_processed_at_least_once) return;
 		has_processed_at_least_once = true;
 
-		ApplyAssemblyScaleConstraints();
 		PreventAllChildScaling();
 		UpdateConveyors();
 		if (conveyorsTransformPrev != conveyors.Transform) {
@@ -639,12 +638,6 @@ public partial class ConveyorAssembly : Node3D, IComms
 
 	private bool IsSimulationRunning() {
 		return main != null && main.simulationRunning;
-	}
-
-	protected virtual void ApplyAssemblyScaleConstraints()
-	{
-		// There are no constraints for this assembly.
-		// This is where one would lock scale components equal to each other or a constant value, for example.
 	}
 	#endregion _Ready and _PhysicsProcess
 

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -12,7 +12,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 	#region Fields
 	#region Fields / Nodes
-	private Root main;
 	protected TransformMonitoredNode3D conveyors
 	{
 		get
@@ -643,8 +642,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 	public override void _Ready()
 	{
-		main = GetTree().EditedSceneRoot as Root;
-
 		_scalePrev = _cachedScale;
 
 		// Apply the ConveyorsAngle property if needed.
@@ -663,25 +660,13 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		PreventAllChildScaling();
 	}
 
-	bool has_processed_at_least_once = false;
 	public override void _PhysicsProcess(double delta)
 	{
-		// A performance hack: Skip assembly adjustments while the simulation is running.
-		// We do make sure to run at least once though. This covers the situation where
-		// a ConveyorAssembly is created or loaded while the simulation is already running.
-		// Rare, but possible.
-		if (IsSimulationRunning() && has_processed_at_least_once) return;
-		has_processed_at_least_once = true;
-
 		UpdateConveyors();
 
 		_scalePrev = _cachedBasis.Scale;
 		conveyorAnglePrev = ConveyorAngle;
 		conveyorsTransformPrev = _cachedConveyorsTransform;
-	}
-
-	private bool IsSimulationRunning() {
-		return main != null && main.simulationRunning;
 	}
 	#endregion constructor, _Ready, and _PhysicsProcess
 

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -596,7 +596,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		transformPrev = this.Transform;
 
 		// Apply the ConveyorsAngle property if needed.
-		Basis assemblyScale = Basis.Identity.Scaled(this.Basis.Scale);
+		Basis assemblyScale = Basis.Identity.Scaled(_cachedScale);
 		if (conveyors != null) {
 			float conveyorsStartingAngle = (assemblyScale * conveyors.Basis).GetEuler().Z;
 			conveyorAnglePrev = conveyorsStartingAngle;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -33,7 +33,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private TransformMonitoredNode3D _rightSide;
 	private TransformMonitoredNode3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<TransformMonitoredNode3D>("LeftSide");
 	private TransformMonitoredNode3D _leftSide;
-	private ConveyorAssemblyLegStands legStands => IsInstanceValid(_legStands) ? _legStands : IsInstanceValid(_legStands = GetNodeOrNull<ConveyorAssemblyLegStands>("LegStands")) ? _legStands : null;
+	private ConveyorAssemblyLegStands legStands => this.GetCachedValidNodeOrNull("LegStands", ref _legStands);
 	private ConveyorAssemblyLegStands _legStands;
 	#endregion Fields / Nodes
 	private Transform3D conveyorsTransformPrev;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -34,7 +34,21 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private TransformMonitoredNode3D _rightSide;
 	private TransformMonitoredNode3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<TransformMonitoredNode3D>("LeftSide");
 	private TransformMonitoredNode3D _leftSide;
-	protected TransformMonitoredNode3D legStands => IsInstanceValid(_legStands) ? _legStands : _legStands = GetNodeOrNull<TransformMonitoredNode3D>("LegStands");
+	protected TransformMonitoredNode3D legStands
+	{
+		get
+		{
+			if (!IsInstanceValid(_legStands))
+			{
+				_legStands = GetNodeOrNull<TransformMonitoredNode3D>("LegStands");
+				if (IsInstanceValid(_legStands))
+				{
+					SetupLegStands();
+				}
+			}
+			return _legStands;
+		}
+	}
 	private TransformMonitoredNode3D _legStands;
 	#endregion Fields / Nodes
 	private Transform3D conveyorsTransformPrev;
@@ -641,10 +655,10 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 		// Apply the AutoLegStandsFloorOffset and AutoLegStandsIntervalLegsOffset properties if needed.
 		if (legStands != null) {
-			Vector3 legStandsStartingOffset = assemblyScale * legStands.Position;
+			Vector3 legStandsStartingOffset = assemblyScale * _cachedLegStandsPosition;
 			autoLegStandsFloorOffsetPrev = legStandsStartingOffset.Y;
 			autoLegStandsIntervalLegsOffsetPrev = legStandsStartingOffset.X;
-			legStandsTransformPrev = legStands.Transform;
+			legStandsTransformPrev = _cachedLegStandsTransform;
 			SyncLegStandsOffsets();
 		}
 

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -420,7 +420,17 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 	[ExportSubgroup("Placement Margins", "AutoLegStandsMargin")]
 	[Export(PropertyHint.Range, "0,1,or_less,or_greater,suffix:m")]
-	public float AutoLegStandsMarginEnds = 0.2f;
+	public float AutoLegStandsMarginEnds
+	{
+		get => _autoLegStandsMarginEnds;
+		set
+		{
+			if (_autoLegStandsMarginEnds == value) return;
+			_autoLegStandsMarginEnds = value;
+			if (IsInstanceValid(legStands)) legStands.UpdateLegStandCoverage();
+		}
+	}
+	private float _autoLegStandsMarginEnds = 0.2f;
 	[Export(PropertyHint.Range, "0.5,5,or_greater,suffix:m")]
 	public float AutoLegStandsMarginEndLegs = 0.5f;
 
@@ -430,10 +440,12 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		get => _autoLegStandsModelGrabsOffset;
 		set
 		{
+			if (_autoLegStandsModelGrabsOffset == value) return;
 			_autoLegStandsModelGrabsOffset = value;
 			if (IsInstanceValid(legStands))
 			{
 				legStands.UpdateLegStandsHeightAndVisibility();
+				legStands.UpdateLegStandCoverage();
 			}
 		}
 	}

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -448,7 +448,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private float legStandCoverageMaxPrev;
 	#endregion Fields / Leg stand coverage
 
-	#region Fields / Length, Width, and Height
+	#region Fields / Length, Width, Height, Basis
+	private Basis _cachedBasis = Basis.Identity;
 	private Vector3 _cachedScale = Vector3.One;
 
 	private float _length;
@@ -489,7 +490,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		if (_height == height) return;
 		_height = height;
 	}
-	#endregion Fields / Length, Width, and Height
+	#endregion Fields / Length, Width, Height, Basis
 
 	// This variable is used to store the names of the pre-existing leg stands that can't be owned by the edited scene.
 	private Dictionary <StringName, Node> foreignLegStandsOwners = new();
@@ -601,6 +602,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#region constructor, _Ready, and _PhysicsProcess
 	public ConveyorAssembly()
 	{
+		BasisChanged += void (value) => _cachedBasis = value;
 		ScaleChanged += void (value) => _cachedScale = value;
 		ScaleXChanged += void (value) => SetLength(value * BaseLength);
 		ScaleZChanged += void (value) => SetWidth(value * BaseWidth);

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -5,6 +5,12 @@ using System.Linq;
 [Tool]
 public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 {
+	#region Constants
+	protected virtual float BaseLength => 1f;
+	protected virtual float BaseWidth => 2f;
+	protected virtual float BaseHeight => 2f;
+	#endregion Constants
+
 	#region Fields
 	#region Fields / Nodes
 	private Root main;
@@ -445,7 +451,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#region Fields / Length, Width, and Height
 	private Vector3 _cachedScale = Vector3.One;
 
-	private float _length = 1f;
+	private float _length;
 	public float Length
 	{
 		get => _length;
@@ -458,7 +464,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		_length = length;
 	}
 
-	private float _width = 2f;
+	private float _width;
 	public float Width
 	{
 		get => _width;
@@ -471,7 +477,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		_width = width;
 	}
 
-	private float _height = 2f;
+	private float _height;
 	public float Height
 	{
 		get => _height;
@@ -596,10 +602,14 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	public ConveyorAssembly()
 	{
 		ScaleChanged += void (value) => _cachedScale = value;
-		ScaleXChanged += SetLength;
-		ScaleZChanged += void (value) => SetWidth(value * 2f);
-		ScaleYChanged += void (value) => SetHeight(value * 2f);
+		ScaleXChanged += void (value) => SetLength(value * BaseLength);
+		ScaleZChanged += void (value) => SetWidth(value * BaseWidth);
+		ScaleYChanged += void (value) => SetHeight(value * BaseHeight);
 
+		// Initialize with default values
+		Length = BaseLength;
+		Width = BaseWidth;
+		Height = BaseHeight;
 		// If necessary, trigger signals to set new values
 		SetTransform(Transform);
 	}

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -33,7 +33,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private TransformMonitoredNode3D _rightSide;
 	private TransformMonitoredNode3D leftSide => IsInstanceValid(_leftSide) ? _leftSide : _leftSide = GetNodeOrNull<TransformMonitoredNode3D>("LeftSide");
 	private TransformMonitoredNode3D _leftSide;
-	private ConveyorAssemblyLegStands legStands => IsInstanceValid(_legStands) ? _legStands : _legStands = GetNodeOrNull<ConveyorAssemblyLegStands>("LegStands");
+	private ConveyorAssemblyLegStands legStands => IsInstanceValid(_legStands) ? _legStands : IsInstanceValid(_legStands = GetNodeOrNull<ConveyorAssemblyLegStands>("LegStands")) ? _legStands : null;
 	private ConveyorAssemblyLegStands _legStands;
 	#endregion Fields / Nodes
 	private Transform3D conveyorsTransformPrev;
@@ -427,7 +427,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		{
 			if (_autoLegStandsMarginEnds == value) return;
 			_autoLegStandsMarginEnds = value;
-			if (IsInstanceValid(legStands)) legStands.UpdateLegStandCoverage();
+			legStands?.UpdateLegStandCoverage();
 		}
 	}
 	private float _autoLegStandsMarginEnds = 0.2f;
@@ -442,11 +442,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		{
 			if (_autoLegStandsModelGrabsOffset == value) return;
 			_autoLegStandsModelGrabsOffset = value;
-			if (IsInstanceValid(legStands))
-			{
-				legStands.UpdateLegStandsHeightAndVisibility();
-				legStands.UpdateLegStandCoverage();
-			}
+			legStands?.UpdateLegStandsHeightAndVisibility();
+			legStands?.UpdateLegStandCoverage();
 		}
 	}
 	private float _autoLegStandsModelGrabsOffset = 0.382f;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -724,7 +724,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		}
 	}
 
-	internal Transform3D PreventChildScaling(Transform3D childTransform, Basis basisPrev) {
+	private Transform3D PreventChildScaling(Transform3D childTransform, Basis basisPrev) {
 		// The child transform without the effects of the parent's scale.
 		var apparentChildTransform = UnapplyInverseScaling(basisPrev, childTransform);
 
@@ -736,7 +736,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		return newChildTransform;
 	}
 
-	private static Transform3D UnapplyInverseScaling(Basis parentBasis, Transform3D childTransform)
+	internal static Transform3D UnapplyInverseScaling(Basis parentBasis, Transform3D childTransform)
 	{
 		var basisRotation = parentBasis.Orthonormalized();
 		var basisScale = basisRotation.Inverse() * parentBasis;
@@ -747,7 +747,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		return apparentChildTransform;
 	}
 
-	private static Transform3D ApplyInverseScaling(Basis parentBasis, Transform3D apparentChildTransform)
+	internal static Transform3D ApplyInverseScaling(Basis parentBasis, Transform3D apparentChildTransform)
 	{
 		var basisRotation = parentBasis.Orthonormalized();
 		var basisScale = basisRotation.Inverse() * parentBasis;

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -458,24 +458,45 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#endregion Fields / Leg stand coverage
 
 	#region Fields / Length, Width, and Height
-	private Vector3 _cachedScale => Scale;
+	private Vector3 _cachedScale;
 
+	private float _length;
 	public float Length
 	{
-		get => Scale.X;
-		set => Scale = new Vector3(value, Scale.Y, Scale.Z);
+		get => _length;
+		set => SetLength(value);
 	}
 
+	public void SetLength(float length)
+	{
+		if (_length == length) return;
+		_length = length;
+	}
+
+	private float _width;
 	public float Width
 	{
-		get => Scale.Z * 2f;
-		set => Scale = new Vector3(Scale.X, Scale.Y, value / 2f);
+		get => _width;
+		set => SetWidth(value);
 	}
 
+	public void SetWidth(float width)
+	{
+		if (_width == width) return;
+		_width = width;
+	}
+
+	private float _height;
 	public float Height
 	{
-		get => Scale.Y * 2f;
-		set => Scale = new Vector3(Scale.X, value / 2f, Scale.Z);
+		get => _height;
+		set => SetHeight(value);
+	}
+
+	public void SetHeight(float height)
+	{
+		if (_height == height) return;
+		_height = height;
 	}
 	#endregion Fields / Length, Width, and Height
 
@@ -586,7 +607,15 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	#endregion Fields / Property method overrides
 	#endregion Fields
 
-	#region _Ready and _PhysicsProcess
+	#region constructor, _Ready, and _PhysicsProcess
+	public ConveyorAssembly()
+	{
+		ScaleChanged += void (value) => _cachedScale = value;
+		ScaleXChanged += SetLength;
+		ScaleZChanged += void (value) => SetWidth(value * 2f);
+		ScaleYChanged += void (value) => SetHeight(value * 2f);
+	}
+
 	public override void _Ready()
 	{
 		main = GetTree().EditedSceneRoot as Root;
@@ -661,7 +690,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private bool IsSimulationRunning() {
 		return main != null && main.simulationRunning;
 	}
-	#endregion _Ready and _PhysicsProcess
+	#endregion constructor, _Ready, and _PhysicsProcess
 
 	#region Decouple assembly scale from child scale
 	private void PreventAllChildScaling() {

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -678,13 +678,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	public override void _Ready()
 	{
 		UpdateSides();
-
 		PreventAllChildScaling();
-	}
-
-	public override void _PhysicsProcess(double delta)
-	{
-		UpdateConveyors();
 	}
 	#endregion constructor, _Ready, and _PhysicsProcess
 

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -692,6 +692,13 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	 * @param child The child node to prevent scaling.
 	 */
 	private void PreventChildScaling(Node3D child) {
+		Transform3D result = PreventChildScaling(child.Transform);
+		if (child.Transform != result) {
+			child.Transform = result;
+		}
+	}
+
+	private Transform3D PreventChildScaling(Transform3D childTransform) {
 		var basisRotation = _cachedBasis.Orthonormalized();
 		var basisScale = basisRotation.Inverse() * _cachedBasis;
 		var xformScaleInverse = new Transform3D(basisScale, new Vector3(0, 0, 0)).AffineInverse();
@@ -701,7 +708,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		var xformScalePrev = new Transform3D(basisScalePrev, new Vector3(0, 0, 0));
 
 		// The child transform without the effects of the parent's scale.
-		var childTransformUnscaled = xformScalePrev * child.Transform;
+		var childTransformUnscaled = xformScalePrev * childTransform;
 
 		// Remove any remaining scale. This effectively locks child's scale to (1, 1, 1).
 		childTransformUnscaled.Basis = childTransformUnscaled.Basis.Orthonormalized();
@@ -711,9 +718,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 
 		// Reapply inverse parent scaling to child.
 		var result = xformScaleInverse * childTransformUnscaled;
-		if (child.Transform != result) {
-			child.Transform = result;
-		}
+		return result;
 	}
 	#endregion Decouple assembly scale from child scale
 }

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -34,7 +34,6 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private Node3D leftSide;
 	protected Node3D legStands;
 	#endregion Fields / Nodes
-	private Transform3D transformPrev;
 	private Transform3D conveyorsTransformPrev;
 	private Transform3D legStandsTransformPrev;
 
@@ -452,6 +451,9 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 	private Basis _cachedBasis = Basis.Identity;
 	private Vector3 _cachedScale = Vector3.One;
 
+	private Basis _basisPrev = Basis.Identity;
+	private Vector3 _scalePrev = Vector3.One;
+
 	private float _length;
 	public float Length
 	{
@@ -622,7 +624,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		conveyors = GetNode<Node3D>("Conveyors");
 		legStands = GetNodeOrNull<Node3D>("LegStands");
 
-		transformPrev = this.Transform;
+		_basisPrev = _cachedBasis;
+		_scalePrev = _basisPrev.Scale;
 
 		// Apply the ConveyorsAngle property if needed.
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedScale);
@@ -677,7 +680,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		}
 		UpdateLegStandCoverage();
 		UpdateLegStands();
-		transformPrev = this.Transform;
+		_basisPrev = _cachedBasis;
+		_scalePrev = _basisPrev.Scale;
 		conveyorAnglePrev = ConveyorAngle;
 		conveyorsTransformPrev = conveyors.Transform;
 		autoLegStandsIntervalLegsEnabledPrev = AutoLegStandsIntervalLegsEnabled;
@@ -720,8 +724,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		var basisScale = basisRotation.Inverse() * _cachedBasis;
 		var xformScaleInverse = new Transform3D(basisScale, new Vector3(0, 0, 0)).AffineInverse();
 
-		var basisRotationPrev = transformPrev.Basis.Orthonormalized();
-		var basisScalePrev = basisRotationPrev.Inverse() * transformPrev.Basis;
+		var basisRotationPrev = _basisPrev.Orthonormalized();
+		var basisScalePrev = basisRotationPrev.Inverse() * _basisPrev;
 		var xformScalePrev = new Transform3D(basisScalePrev, new Vector3(0, 0, 0));
 
 		// The child transform without the effects of the parent's scale.

--- a/src/Assembly/ConveyorAssemblyChild.cs
+++ b/src/Assembly/ConveyorAssemblyChild.cs
@@ -11,6 +11,12 @@ public partial class ConveyorAssemblyChild : TransformMonitoredNode3D
 		return PreventScaling(transform, assembly);
 	}
 
+	protected virtual Transform3D ConstrainApparentTransform(Transform3D transform)
+	{
+		var basis = transform.Basis.Orthonormalized();
+		return new Transform3D(basis, transform.Origin);
+	}
+
 	internal Transform3D PreventScaling()
 	{
 		return PreventScaling(Transform, assembly);
@@ -18,9 +24,11 @@ public partial class ConveyorAssemblyChild : TransformMonitoredNode3D
 
 	private Transform3D PreventScaling(Transform3D transform, ConveyorAssembly assembly)
 	{
-		if (!IsInstanceValid(assembly)) return transform;
-		var result = assembly.PreventChildScaling(transform, assemblyBasisAtLastRescale);
+		if (!IsInstanceValid(assembly)) return ConstrainApparentTransform(transform);
+		var apparentTransform = ConveyorAssembly.UnapplyInverseScaling(assemblyBasisAtLastRescale, transform);
+		apparentTransform = ConstrainApparentTransform(apparentTransform);
 		assemblyBasisAtLastRescale = assembly.Basis;
+		var result = ConveyorAssembly.ApplyInverseScaling(assemblyBasisAtLastRescale, apparentTransform);
 		return result;
 	}
 }

--- a/src/Assembly/ConveyorAssemblyChild.cs
+++ b/src/Assembly/ConveyorAssemblyChild.cs
@@ -3,8 +3,24 @@ using Godot;
 [Tool]
 public partial class ConveyorAssemblyChild : TransformMonitoredNode3D
 {
+	private ConveyorAssembly assembly => GetParentOrNull<ConveyorAssembly>();
+	private Basis assemblyBasisAtLastRescale = Basis.Identity;
+
 	protected override Transform3D ConstrainTransform(Transform3D transform)
 	{
-		return transform;
+		return PreventScaling(transform, assembly);
+	}
+
+	internal Transform3D PreventScaling()
+	{
+		return PreventScaling(Transform, assembly);
+	}
+
+	private Transform3D PreventScaling(Transform3D transform, ConveyorAssembly assembly)
+	{
+		if (!IsInstanceValid(assembly)) return transform;
+		var result = assembly.PreventChildScaling(transform, assemblyBasisAtLastRescale);
+		assemblyBasisAtLastRescale = assembly.Basis;
+		return result;
 	}
 }

--- a/src/Assembly/ConveyorAssemblyChild.cs
+++ b/src/Assembly/ConveyorAssemblyChild.cs
@@ -1,0 +1,10 @@
+using Godot;
+
+[Tool]
+public partial class ConveyorAssemblyChild : TransformMonitoredNode3D
+{
+	protected override Transform3D ConstrainTransform(Transform3D transform)
+	{
+		return transform;
+	}
+}

--- a/src/Assembly/ConveyorAssemblyConveyors.cs
+++ b/src/Assembly/ConveyorAssemblyConveyors.cs
@@ -3,4 +3,10 @@ using Godot;
 [Tool]
 public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
 {
+	private ConveyorAssembly assembly => GetParentOrNull<ConveyorAssembly>();
+
+	protected override Transform3D ConstrainApparentTransform(Transform3D transform)
+	{
+		return base.ConstrainApparentTransform(assembly.LockConveyorsGroup(transform));
+	}
 }

--- a/src/Assembly/ConveyorAssemblyConveyors.cs
+++ b/src/Assembly/ConveyorAssemblyConveyors.cs
@@ -5,6 +5,12 @@ public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
 {
 	private ConveyorAssembly assembly => GetParentOrNull<ConveyorAssembly>();
 
+	public override void _PhysicsProcess(double delta)
+	{
+		if (assembly == null) return;
+		assembly.UpdateConveyors();
+	}
+
 	protected override Transform3D ConstrainApparentTransform(Transform3D transform)
 	{
 		return base.ConstrainApparentTransform(assembly.LockConveyorsGroup(transform));

--- a/src/Assembly/ConveyorAssemblyConveyors.cs
+++ b/src/Assembly/ConveyorAssemblyConveyors.cs
@@ -9,4 +9,12 @@ public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
 	{
 		return base.ConstrainApparentTransform(assembly.LockConveyorsGroup(transform));
 	}
+
+	public void SetAngle(float angle)
+	{
+		PreventScaling();
+		Basis scale = Basis.Identity.Scaled(assembly.Scale);
+		Basis targetRot = new Basis(new Vector3(0, 0, 1), angle);
+		this.Basis = scale.Inverse() * targetRot;
+	}
 }

--- a/src/Assembly/ConveyorAssemblyConveyors.cs
+++ b/src/Assembly/ConveyorAssemblyConveyors.cs
@@ -9,6 +9,7 @@ public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
 	{
 		if (assembly == null) return;
 		assembly.UpdateConveyors();
+		SetNeedsUpdate(false);
 	}
 
 	protected override Transform3D ConstrainApparentTransform(Transform3D transform)
@@ -22,5 +23,10 @@ public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
 		Basis scale = Basis.Identity.Scaled(assembly.Scale);
 		Basis targetRot = new Basis(new Vector3(0, 0, 1), angle);
 		this.Basis = scale.Inverse() * targetRot;
+	}
+
+	internal void SetNeedsUpdate(bool value)
+	{
+		SetPhysicsProcess(value);
 	}
 }

--- a/src/Assembly/ConveyorAssemblyConveyors.cs
+++ b/src/Assembly/ConveyorAssemblyConveyors.cs
@@ -1,0 +1,6 @@
+using Godot;
+
+[Tool]
+public partial class ConveyorAssemblyConveyors : ConveyorAssemblyChild
+{
+}

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -177,7 +177,14 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 			DeleteAllAutoLegStands();
 		}
 
-		SnapAllLegStandsToPath();
+		// Only bother repositioning leg stands if the user could manually edit them.
+		// All the leg stands that we generated should already be in the right spots.
+		var editedRoot = GetTree().EditedSceneRoot;
+		bool legStandsIsEditable = editedRoot != null && (editedRoot == Owner || editedRoot.IsEditableInstance(Owner));
+		if (legStandsIsEditable)
+		{
+			SnapAllLegStandsToPath();
+		}
 
 		bool debugInvariants = true;
 		float legStandCoverageMinValueForAssertion = 0;

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -74,6 +74,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		SetTransform(Transform);
 
 		TransformChanged += void (_) => UpdateLegStandCoverage();
+		PositionChanged += void (_) => SyncLegStandsOffsets();
 	}
 
 	public override void _Ready()
@@ -171,8 +172,6 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 	private void UpdateLegStands()
 	{
-		SyncLegStandsOffsets();
-
 		// If the leg stand scene changes, we need to regenerate everything.
 		if (assembly.AutoLegStandsModelScene != autoLegStandsModelScenePrev) {
 			DeleteAllAutoLegStands();
@@ -269,7 +268,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	 *
 	 * This currently shouldn't do anything for curved assemblies.
 	 */
-	private void SyncLegStandsOffsets() {
+	internal void SyncLegStandsOffsets() {
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedAssemblyScale);
 		Vector3 legStandsScaledPosition = assemblyScale * _cachedLegStandsPosition;
 

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -26,9 +26,6 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	private TransformMonitoredNode3D _conveyors;
 	// TODO actually cache
 	private Transform3D _cachedConveyorsTransform => conveyors?.Transform ?? Transform3D.Identity;
-	private Vector3 _cachedConveyorsPosition => conveyors?.Position ?? Vector3.Zero;
-	private Basis _cachedConveyorsBasis => conveyors?.Basis ?? Basis.Identity;
-	private Vector3 _cachedConveyorsRotation => conveyors?.Rotation ?? Vector3.Zero;
 	private Vector3 _cachedAssemblyScale => assembly?.Scale ?? Vector3.One;
 
 	#region Leg Stands

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -62,6 +62,8 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	private float autoLegStandsMarginEndLegsPrev = 0.5f;
 	private PackedScene autoLegStandsModelScenePrev;
 
+	protected bool legStandsPathChanged = true;
+
 	public ConveyorAssemblyLegStands()
 	{
 		TransformChanged += void (value) => _cachedLegStandsTransform = value;
@@ -191,10 +193,12 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		// All the leg stands that we generated should already be in the right spots.
 		var editedRoot = GetTree().EditedSceneRoot;
 		bool legStandsIsEditable = editedRoot != null && (editedRoot == Owner || editedRoot.IsEditableInstance(Owner));
-		if (legStandsIsEditable)
+		if (legStandsIsEditable || legStandsPathChanged)
 		{
 			SnapAllLegStandsToPath();
 		}
+		legStandsPathChanged = false;
+
 		float targetWidthNew = GetLegStandTargetWidth();
 		bool targetWidthChanged = targetWidthPrev != targetWidthNew;
 		targetWidthPrev = targetWidthNew;

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -233,20 +233,13 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 	protected virtual Transform3D LockLegStandsGroup(Transform3D transform) {
 		// Always align LegStands group with Conveyors group.
-		Transform3D newTransform = transform;
-		if (conveyors != null) {
-			Vector3 newPos = new Vector3(transform.Origin.X, transform.Origin.Y, _cachedConveyorsPosition.Z);
-			if (_cachedLegStandsPosition != newPos) {
-				newTransform.Origin = newPos;
-			}
-			// Conveyors can't rotate anymore, so this doesn't do much.
-			Vector3 newRot = new Vector3(0f, _cachedConveyorsRotation.Y, 0f);
-			if (_cachedLegStandsRotation != newRot) {
-				var scale = newTransform.Basis.Scale;
-				newTransform.Basis = Basis.FromEuler(newRot).Scaled(scale);
-			}
-		}
-		return newTransform;
+		if (conveyors == null) return transform;
+		var position = new Vector3(transform.Origin.X, transform.Origin.Y, _cachedConveyorsPosition.Z);
+		// Conveyors can't rotate anymore, so this doesn't do much.
+		var rotation = new Vector3(0f, _cachedConveyorsRotation.Y, 0f);
+		var scale = transform.Basis.Scale;
+		var basis = Basis.FromEuler(rotation).Scaled(scale);
+		return new Transform3D(basis, position);
 	}
 
 	/**

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -171,7 +171,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	#region Leg Stands / Update "LegStands" node
 	protected override Transform3D ConstrainTransform(Transform3D transform)
 	{
-		return LockLegStandsGroup(transform);
+		return LockLegStandsGroup(base.ConstrainTransform(transform));
 	}
 
 	private void UpdateLegStands()

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -50,7 +50,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 	// Configuration change detection fields
 	private Transform3D conveyorsTransformPrev;
-	private Transform3D legStandsTransformPrev;
+	private Basis legStandsBasisPrev;
 	private float conveyorAnglePrev = 0f;
 	private float autoLegStandsFloorOffsetPrev;
 	private bool autoLegStandsIntervalLegsEnabledPrev = false;
@@ -83,7 +83,6 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		Vector3 legStandsStartingOffset = assemblyScale * _cachedLegStandsPosition;
 		autoLegStandsFloorOffsetPrev = legStandsStartingOffset.Y;
 		autoLegStandsIntervalLegsOffsetPrev = legStandsStartingOffset.X;
-		legStandsTransformPrev = _cachedLegStandsTransform;
 		SyncLegStandsOffsets();
 
 		autoLegStandsIntervalLegsIntervalPrev = assembly.AutoLegStandsIntervalLegsInterval;
@@ -210,7 +209,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		// Dependencies
 		bool legStandsChildrenChanged = numberOfLegStandsAdjusted != 0 || didAddOrRemove;
 		bool conveyorsTransformChanged = _cachedConveyorsTransform != conveyorsTransformPrev;
-		bool legStandsBasisChanged = _cachedLegStandsBasis != legStandsTransformPrev.Basis;
+		bool legStandsBasisChanged = _cachedLegStandsBasis != legStandsBasisPrev;
 		if (legStandsChildrenChanged || conveyorsTransformChanged || legStandsBasisChanged || legStandsCoverageChanged)
 		{
 			UpdateLegStandsHeightAndVisibility();
@@ -218,6 +217,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 		// Record external state to detect any changes next run.
 		conveyorsTransformPrev = _cachedConveyorsTransform;
+		legStandsBasisPrev = _cachedLegStandsBasis;
 		autoLegStandsIntervalLegsEnabledPrev = assembly.AutoLegStandsIntervalLegsEnabled;
 		autoLegStandsEndLegFrontPrev = assembly.AutoLegStandsEndLegFront;
 		autoLegStandsEndLegRearPrev = assembly.AutoLegStandsEndLegRear;
@@ -278,8 +278,6 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 			assembly.AutoLegStandsFloorOffset = offset;
 		}
 		autoLegStandsFloorOffsetPrev = assembly.AutoLegStandsFloorOffset;
-
-		legStandsTransformPrev = _cachedLegStandsTransform;
 	}
 
 	private void DeleteAllAutoLegStands() {

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -102,6 +102,12 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	public override void _PhysicsProcess(double delta)
 	{
 		UpdateLegStands();
+		SetNeedsUpdate(false);
+	}
+
+	internal void SetNeedsUpdate(bool value)
+	{
+		SetPhysicsProcess(value);
 	}
 
 	#region Fields / Leg stand coverage

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -74,7 +74,10 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 			_cachedLegStandsRotation = _cachedLegStandsBasis.GetEuler();
 		};
 		// Ensure cached values are up to date
-		SetTransform(Transform);
+		_cachedLegStandsTransform = Transform;
+		_cachedLegStandsPosition = _cachedLegStandsTransform.Origin;
+		_cachedLegStandsBasis = _cachedLegStandsTransform.Basis;
+		_cachedLegStandsRotation = _cachedLegStandsBasis.GetEuler();
 
 		TransformChanged += void (_) => UpdateLegStandCoverage();
 		PositionChanged += void (_) => SyncLegStandsOffsets();

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -272,23 +272,27 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedAssemblyScale);
 		Vector3 legStandsScaledPosition = assemblyScale * _cachedLegStandsPosition;
 
+		bool xConfigChanged = assembly.AutoLegStandsIntervalLegsOffset != autoLegStandsIntervalLegsOffsetPrev;
+		bool yConfigChanged = assembly.AutoLegStandsFloorOffset != autoLegStandsFloorOffsetPrev;
+
 		// Sync properties to leg stands position if changed.
-		float newPosX = assembly.AutoLegStandsIntervalLegsOffset != autoLegStandsIntervalLegsOffsetPrev ? assembly.AutoLegStandsIntervalLegsOffset : legStandsScaledPosition.X;
-		float newPosY = assembly.AutoLegStandsFloorOffset != autoLegStandsFloorOffsetPrev ? assembly.AutoLegStandsFloorOffset : legStandsScaledPosition.Y;
-		if (assembly.AutoLegStandsIntervalLegsOffset != autoLegStandsIntervalLegsOffsetPrev || assembly.AutoLegStandsFloorOffset != autoLegStandsFloorOffsetPrev) {
+		float newPosX = xConfigChanged ? assembly.AutoLegStandsIntervalLegsOffset : legStandsScaledPosition.X;
+		float newPosY = yConfigChanged ? assembly.AutoLegStandsFloorOffset : legStandsScaledPosition.Y;
+
+		if (xConfigChanged || yConfigChanged) {
 			Vector3 targetPosition = new Vector3(newPosX, newPosY, legStandsScaledPosition.Z);
 			Position = assemblyScale.Inverse() * targetPosition;
 		}
 
 		// Sync X offset to property if needed.
-		if (assembly.AutoLegStandsIntervalLegsOffset == autoLegStandsIntervalLegsOffsetPrev) {
+		if (!xConfigChanged) {
 			float offset = legStandsScaledPosition.X;
 			assembly.AutoLegStandsIntervalLegsOffset = offset;
 		}
 		autoLegStandsIntervalLegsOffsetPrev = assembly.AutoLegStandsIntervalLegsOffset;
 
 		// Sync Y offset to property if needed.
-		if (assembly.AutoLegStandsFloorOffset == autoLegStandsFloorOffsetPrev) {
+		if (!yConfigChanged) {
 			float offset = legStandsScaledPosition.Y;
 			assembly.AutoLegStandsFloorOffset = offset;
 		}

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 [Tool]
-public partial class ConveyorAssemblyLegStands : TransformMonitoredNode3D
+public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 {
 	// Workarounds for renaming class
 	private ConveyorAssembly assembly => GetParentOrNull<ConveyorAssembly>();

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -225,19 +225,28 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		(legStandCoverageMinPrev, legStandCoverageMaxPrev) = (legStandCoverageMin, legStandCoverageMax);
 	}
 
-	protected virtual void LockLegStandsGroup() {
+	private void LockLegStandsGroup() {
+		var newTransform = LockLegStandsGroup(Transform);
+		if (Transform == newTransform) return;
+		Transform = newTransform;
+	}
+
+	protected virtual Transform3D LockLegStandsGroup(Transform3D transform) {
 		// Always align LegStands group with Conveyors group.
+		Transform3D newTransform = transform;
 		if (conveyors != null) {
-			Vector3 newPos = new Vector3(_cachedLegStandsPosition.X, _cachedLegStandsPosition.Y, _cachedConveyorsPosition.Z);
+			Vector3 newPos = new Vector3(transform.Origin.X, transform.Origin.Y, _cachedConveyorsPosition.Z);
 			if (_cachedLegStandsPosition != newPos) {
-				Position = newPos;
+				newTransform.Origin = newPos;
 			}
 			// Conveyors can't rotate anymore, so this doesn't do much.
 			Vector3 newRot = new Vector3(0f, _cachedConveyorsRotation.Y, 0f);
 			if (_cachedLegStandsRotation != newRot) {
-				Rotation = newRot;
+				var scale = newTransform.Basis.Scale;
+				newTransform.Basis = Basis.FromEuler(newRot).Scaled(scale);
 			}
 		}
+		return newTransform;
 	}
 
 	/**

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -180,6 +180,16 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 		SnapAllLegStandsToPath();
 
+		bool debugInvariants = true;
+		float legStandCoverageMinValueForAssertion = 0;
+		float legStandCoverageMaxValueForAssertion = 0;
+		if (debugInvariants)
+		{
+			// debug: Prepare to assert that legStandCoverage has not changed in this code block
+			legStandCoverageMinValueForAssertion = legStandCoverageMin;
+			legStandCoverageMaxValueForAssertion = legStandCoverageMax;
+		}
+
 		bool legStandsCoverageChanged = legStandCoverageMin != legStandCoverageMinPrev
 		                                || legStandCoverageMax != legStandCoverageMaxPrev;
 
@@ -224,6 +234,12 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		autoLegStandsMarginEndLegsPrev = assembly.AutoLegStandsMarginEndLegs;
 		autoLegStandsModelScenePrev = assembly.AutoLegStandsModelScene;
 		(legStandCoverageMinPrev, legStandCoverageMaxPrev) = (legStandCoverageMin, legStandCoverageMax);
+
+		if (debugInvariants)
+		{
+			System.Diagnostics.Debug.Assert(legStandCoverageMin == legStandCoverageMinValueForAssertion, "Unexpected change detected: legStandCoverateMin");
+			System.Diagnostics.Debug.Assert(legStandCoverageMax == legStandCoverageMaxValueForAssertion, "Unexpected change detected: legStandCoverateMax");
+		}
 	}
 
 	private void LockLegStandsGroup() {

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -190,6 +190,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		if (legStandsIsEditable)
 		{
 			SnapAllLegStandsToPath();
+			UpdateAllLegStandsWidth();
 		}
 
 		bool debugInvariants = true;
@@ -332,16 +333,24 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	#region Leg Stands / Basic constraints
 	private void SnapAllLegStandsToPath() {
 		// Force legStand alignment with LegStands group.
-		float targetWidth = GetLegStandTargetWidth();
 		foreach (Node child in GetChildren()) {
 			ConveyorLeg legStand = child as ConveyorLeg;
 			if (legStand == null) {
 				continue;
 			}
 			SnapToLegStandsPath(legStand);
+		}
+	}
+
+	private void UpdateAllLegStandsWidth() {
+		float targetWidth = GetLegStandTargetWidth();
+		foreach (Node child in GetChildren()) {
+			ConveyorLeg legStand = child as ConveyorLeg;
+			if (legStand == null) {
+				continue;
+			}
 			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / LegStandsBaseWidth);
 		}
-
 	}
 
 	private float GetLegStandTargetWidth() {

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -239,9 +239,9 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	protected virtual Transform3D LockLegStandsGroup(Transform3D transform) {
 		// Always align LegStands group with Conveyors group.
 		if (conveyors == null) return transform;
-		var position = new Vector3(transform.Origin.X, transform.Origin.Y, _cachedConveyorsPosition.Z);
+		var position = new Vector3(transform.Origin.X, transform.Origin.Y, conveyors.Position.Z);
 		// Conveyors can't rotate anymore, so this doesn't do much.
-		var rotation = new Vector3(0f, _cachedConveyorsRotation.Y, 0f);
+		var rotation = new Vector3(0f, conveyors.Rotation.Y, 0f);
 		var scale = transform.Basis.Scale;
 		var basis = Basis.FromEuler(rotation).Scaled(scale);
 		return new Transform3D(basis, position);

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -50,7 +50,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 	// Configuration change detection fields
 	private Transform3D conveyorsTransformPrev;
-	private Basis legStandsBasisPrev;
+	private Transform3D legStandsTransformPrev;
 	private float conveyorAnglePrev = 0f;
 	private float autoLegStandsFloorOffsetPrev;
 	private bool autoLegStandsIntervalLegsEnabledPrev = false;
@@ -217,16 +217,19 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 		// Dependencies
 		bool legStandsChildrenChanged = numberOfLegStandsAdjusted != 0 || didAddOrRemove;
+		// Actually, it's the relative transform of LegStands and Conveyors that we need to monitor,
+		// specifically the conveyorPlane in UpdateLegStandsHeightAndVisibility,
+		// but the individual Transforms are good enough for now, though overkill.
 		bool conveyorsTransformChanged = _cachedConveyorsTransform != conveyorsTransformPrev;
-		bool legStandsBasisChanged = _cachedLegStandsBasis != legStandsBasisPrev;
-		if (legStandsChildrenChanged || conveyorsTransformChanged || legStandsBasisChanged || legStandsCoverageChanged)
+		bool legStandsTransformChanged = _cachedLegStandsTransform != legStandsTransformPrev;
+		if (legStandsChildrenChanged || conveyorsTransformChanged || legStandsTransformChanged || legStandsCoverageChanged)
 		{
 			UpdateLegStandsHeightAndVisibility();
 		}
 
 		// Record external state to detect any changes next run.
 		conveyorsTransformPrev = _cachedConveyorsTransform;
-		legStandsBasisPrev = _cachedLegStandsBasis;
+		legStandsTransformPrev = _cachedLegStandsTransform;
 		autoLegStandsIntervalLegsEnabledPrev = assembly.AutoLegStandsIntervalLegsEnabled;
 		autoLegStandsEndLegFrontPrev = assembly.AutoLegStandsEndLegFront;
 		autoLegStandsEndLegRearPrev = assembly.AutoLegStandsEndLegRear;

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -51,6 +51,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	// Configuration change detection fields
 	private Transform3D conveyorsTransformPrev;
 	private Transform3D legStandsTransformPrev;
+	private float targetWidthPrev = LegStandsBaseWidth;
 	private float conveyorAnglePrev = 0f;
 	private float autoLegStandsFloorOffsetPrev;
 	private bool autoLegStandsIntervalLegsEnabledPrev = false;
@@ -79,6 +80,9 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 
 	public override void _Ready()
 	{
+		assembly.ScaleChanged += void (_) => SetNeedsUpdate(true);
+		conveyors.BasisChanged += void (_) => SetNeedsUpdate(true);
+
 		// Apply the AutoLegStandsFloorOffset and AutoLegStandsIntervalLegsOffset properties if needed.
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedAssemblyScale);
 		Vector3 legStandsStartingOffset = assemblyScale * _cachedLegStandsPosition;
@@ -190,6 +194,12 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		if (legStandsIsEditable)
 		{
 			SnapAllLegStandsToPath();
+		}
+		float targetWidthNew = GetLegStandTargetWidth();
+		bool targetWidthChanged = targetWidthPrev != targetWidthNew;
+		targetWidthPrev = targetWidthNew;
+		if (legStandsIsEditable || targetWidthChanged)
+		{
 			UpdateAllLegStandsWidth();
 		}
 

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -16,6 +16,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 			_conveyors = assembly?.GetNodeOrNull<TransformMonitoredNode3D>("Conveyors");
 			if (IsInstanceValid(_conveyors))
 			{
+				_conveyors.TransformChanged += void (_) => LockLegStandsGroup();
 				_conveyors.TransformChanged += void (_) => UpdateLegStandCoverage();
 				UpdateLegStandCoverage();
 			}
@@ -168,9 +169,13 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	#endregion Leg Stands / Conveyor coverage extents
 
 	#region Leg Stands / Update "LegStands" node
+	protected override Transform3D ConstrainTransform(Transform3D transform)
+	{
+		return LockLegStandsGroup(transform);
+	}
+
 	private void UpdateLegStands()
 	{
-		LockLegStandsGroup();
 		SyncLegStandsOffsets();
 
 		// If the leg stand scene changes, we need to regenerate everything.

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -30,7 +30,6 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	private Basis _cachedConveyorsBasis => conveyors?.Basis ?? Basis.Identity;
 	private Vector3 _cachedConveyorsRotation => conveyors?.Rotation ?? Vector3.Zero;
 	private Vector3 _cachedAssemblyScale => assembly?.Scale ?? Vector3.One;
-	private Vector3 _assemblyScalePrev => assembly?.Scale ?? Vector3.One;
 
 	#region Leg Stands
 	#region Leg Stands / Constants
@@ -259,9 +258,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	 */
 	private void SyncLegStandsOffsets() {
 		Basis assemblyScale = Basis.Identity.Scaled(_cachedAssemblyScale);
-		Basis assemblyScalePrev = Basis.Identity.Scaled(_assemblyScalePrev);
 		Vector3 legStandsScaledPosition = assemblyScale * _cachedLegStandsPosition;
-		Vector3 legStandsScaledPositionPrev = assemblyScalePrev * legStandsTransformPrev.Origin;
 
 		// Sync properties to leg stands position if changed.
 		float newPosX = assembly.AutoLegStandsIntervalLegsOffset != autoLegStandsIntervalLegsOffsetPrev ? assembly.AutoLegStandsIntervalLegsOffset : legStandsScaledPosition.X;
@@ -274,24 +271,14 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		// Sync X offset to property if needed.
 		if (assembly.AutoLegStandsIntervalLegsOffset == autoLegStandsIntervalLegsOffsetPrev) {
 			float offset = legStandsScaledPosition.X;
-			float offsetPrev = legStandsScaledPositionPrev.X;
-			float offsetDelta = Mathf.Abs(offset - offsetPrev);
-			if (offsetDelta > 0.01f) {
-				assembly.AutoLegStandsIntervalLegsOffset = offset;
-				NotifyPropertyListChanged();
-			}
+			assembly.AutoLegStandsIntervalLegsOffset = offset;
 		}
 		autoLegStandsIntervalLegsOffsetPrev = assembly.AutoLegStandsIntervalLegsOffset;
 
 		// Sync Y offset to property if needed.
 		if (assembly.AutoLegStandsFloorOffset == autoLegStandsFloorOffsetPrev) {
 			float offset = legStandsScaledPosition.Y;
-			float offsetPrev = legStandsScaledPositionPrev.Y;
-			float offsetDelta = Mathf.Abs(offset - offsetPrev);
-			if (offsetDelta > 0.01f) {
-				assembly.AutoLegStandsFloorOffset = offset;
-				NotifyPropertyListChanged();
-			}
+			assembly.AutoLegStandsFloorOffset = offset;
 		}
 		autoLegStandsFloorOffsetPrev = assembly.AutoLegStandsFloorOffset;
 

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -112,13 +112,13 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	protected override void LockConveyorsGroup() {
 		// Just don't let it move at all, except Y axis translation.;
 		conveyors.Rotation = new Vector3(0, 0, 0);
-		conveyors.Position = new Vector3(0, conveyors.Position.Y, 0);
+		conveyors.Position = new Vector3(0, _cachedConveyorsPosition.Y, 0);
 	}
 
 	protected override void LockSidePosition(Node3D side, bool isRight) {
 		// Sides always snap onto the conveyor line
 		// Just snap both sides to the center without any offset.
-		side.Transform = conveyors.Transform;
+		side.Transform = _cachedConveyorsTransform;
 	}
 
 	protected override void ScaleConveyor(Node3D conveyor, float conveyorLength) {

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -143,7 +143,7 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 		// We should probably let this rotate around the Y axis, but that would require accounting for legStands rotation in GetLegStandsCoverage().
 		// For now, we won't let it move at all except Y axis translation.
 		legStands.Rotation = new Vector3(0, 0, 0);
-		legStands.Position = new Vector3(0, legStands.Position.Y, 0);
+		legStands.Position = new Vector3(0, _cachedLegStandsPosition.Y, 0);
 	}
 
 	protected override float GetPositionOnLegStandsPath(Vector3 position) {

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -123,8 +123,9 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 		side.Transform = _cachedConveyorsTransform;
 	}
 
-	protected override void ScaleConveyor(Node3D conveyor, float conveyorLength) {
-		// ConveyorAutomaticLength and conveyorLength have no effect on curved conveyors.
+	protected override void ScaleConveyor(Node3D conveyor, float conveyorLength, float conveyorWidth) {
+		// ConveyorAutomaticLength, conveyorLength, and conveyorWidth have no effect on curved conveyors.
+		// TODO delete this override
 		conveyor.Scale = new Vector3(Length / ConveyorBaseLength, 1f, Width / ConveyorBaseWidth);
 	}
 

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -87,14 +87,15 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	}
 	#endregion Overriding default values and units
 
-	protected override void ApplyAssemblyScaleConstraints() {
+	protected override Transform3D ConstrainTransform(Transform3D transform) {
 		// Lock Z scale to be the same as X scale.
-		(var scaleX, var scaleY, var scaleZ) = this.Transform.Basis.Scale;
+		(var scaleX, var scaleY, var scaleZ) = transform.Basis.Scale;
 		if (scaleX != scaleZ) {
-			Basis rotBasis = this.Transform.Basis.Orthonormalized();
+			Basis rotBasis = transform.Basis.Orthonormalized();
 			rotBasis = new Basis(rotBasis.X * scaleX, rotBasis.Y * scaleY, rotBasis.Z * scaleX);
-			this.Transform = new Transform3D(rotBasis, this.Transform.Origin);
+			return new Transform3D(rotBasis, transform.Origin);
 		}
+		return transform;
 	}
 
 	#region Conveyors and Side Guards

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -113,12 +113,12 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 
 	protected override void ScaleConveyor(Node3D conveyor, float conveyorLength) {
 		// ConveyorAutomaticLength and conveyorLength have no effect on curved conveyors.
-		conveyor.Scale = new Vector3(this.Scale.X, 1f, this.Scale.Z);
+		conveyor.Scale = new Vector3(Length, 1f, Width / 2f);
 	}
 
 	protected override void ScaleSideGuard(Node3D guard, float guardLength) {
 		// SideGuardsAutoScale and guardLength have no effect on curved side guards.
-		guard.Scale = new Vector3(this.Scale.X, 1f, this.Scale.Z);
+		guard.Scale = new Vector3(Length / 2f, 1f, Width / 2f);
 	}
 	#endregion Conveyors and Side Guards
 
@@ -139,7 +139,7 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	}
 
 	protected override void MoveLegStandToPathPosition(Node3D legStand, float position) {
-		float radius = this.Scale.X * 1.5f;
+		float radius = Width / 2f * 1.5f;
 		float angle = Mathf.DegToRad(position);
 
 		Vector3 newPosition = new Vector3(0, legStand.Position.Y, radius).Rotated(Vector3.Up, angle);

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -14,6 +14,8 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	protected override float ConveyorBaseWidth => 2f;
 	#endregion Constants
 
+	public float MiddleRadius => Width / BaseWidth * BaseMiddleRadius;
+
 	#region Overriding default values and units
 	public CurvedConveyorAssembly() {
 		GD.Load<PackedScene>("res://parts/ConveyorLegCBC.tscn");
@@ -133,42 +135,4 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 		guard.Scale = new Vector3(Length / curvedSideGuardBaseLength, 1f, Width / curvedSideGuardBaseWidth);
 	}
 	#endregion Conveyors and Side Guards
-
-	#region Leg Stands
-	protected override (float, float) GetLegStandCoverage() {
-		// Assume that conveyors and legStands have the same rotation.
-		return (-90f + AutoLegStandsMarginEnds, 0f - AutoLegStandsMarginEnds);
-	}
-	protected override void LockLegStandsGroup() {
-		// We should probably let this rotate around the Y axis, but that would require accounting for legStands rotation in GetLegStandsCoverage().
-		// For now, we won't let it move at all except Y axis translation.
-		legStands.Rotation = new Vector3(0, 0, 0);
-		legStands.Position = new Vector3(0, _cachedLegStandsPosition.Y, 0);
-	}
-
-	protected override float GetPositionOnLegStandsPath(Vector3 position) {
-		return (float) Math.Round(Mathf.RadToDeg(new Vector3(0, 0, 1).SignedAngleTo(position.Slide(Vector3.Up), Vector3.Up)));
-	}
-
-	protected override bool MoveLegStandToPathPosition(Node3D legStand, float pathPosition)
-	{
-		float pathRadius = Width / BaseWidth * BaseMiddleRadius;
-		float angle = Mathf.DegToRad(pathPosition);
-
-		bool changed = false;
-		Vector3 newPosition = new Vector3(0, legStand.Position.Y, pathRadius).Rotated(Vector3.Up, angle);
-		if (legStand.Position != newPosition)
-		{
-			legStand.Position = newPosition;
-			changed = true;
-		}
-		Vector3 newRotation = new Vector3(0f, angle, 0f);
-		if (legStand.Rotation != newRotation)
-		{
-			legStand.Rotation = newRotation;
-			changed = true;
-		}
-		return changed;
-	}
-	#endregion Leg Stands
 }

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -150,21 +150,25 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 		return (float) Math.Round(Mathf.RadToDeg(new Vector3(0, 0, 1).SignedAngleTo(position.Slide(Vector3.Up), Vector3.Up)));
 	}
 
-	protected override void MoveLegStandToPathPosition(Node3D legStand, float pathPosition)
+	protected override bool MoveLegStandToPathPosition(Node3D legStand, float pathPosition)
 	{
 		float pathRadius = Width / BaseWidth * BaseMiddleRadius;
 		float angle = Mathf.DegToRad(pathPosition);
 
+		bool changed = false;
 		Vector3 newPosition = new Vector3(0, legStand.Position.Y, pathRadius).Rotated(Vector3.Up, angle);
 		if (legStand.Position != newPosition)
 		{
 			legStand.Position = newPosition;
+			changed = true;
 		}
 		Vector3 newRotation = new Vector3(0f, angle, 0f);
 		if (legStand.Rotation != newRotation)
 		{
 			legStand.Rotation = newRotation;
+			changed = true;
 		}
+		return changed;
 	}
 	#endregion Leg Stands
 }

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -111,10 +111,11 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	}
 
 	#region Conveyors and Side Guards
-	protected override void LockConveyorsGroup() {
+	protected override Transform3D LockConveyorsGroup(Transform3D transform) {
 		// Just don't let it move at all, except Y axis translation.;
-		conveyors.Rotation = new Vector3(0, 0, 0);
-		conveyors.Position = new Vector3(0, _cachedConveyorsPosition.Y, 0);
+		var scale = transform.Basis.Scale;
+		var position = new Vector3(0, transform.Origin.Y, 0);
+		return new Transform3D(Basis.Identity.Scaled(scale), position);
 	}
 
 	protected override void LockSidePosition(Node3D side, bool isRight) {

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -4,6 +4,16 @@ using System;
 [Tool]
 public partial class CurvedConveyorAssembly : ConveyorAssembly
 {
+	#region Constants
+	float BaseOuterRadius => 2.0f;
+	float BaseInnerRadius => 0.5f;
+	float BaseMiddleRadius => BaseOuterRadius - BaseInnerRadius;
+	protected override float BaseLength => 2.0f;
+	protected override float BaseWidth => 2.0f;
+	protected override float ConveyorBaseLength => 2f;
+	protected override float ConveyorBaseWidth => 2f;
+	#endregion Constants
+
 	#region Overriding default values and units
 	public CurvedConveyorAssembly() {
 		GD.Load<PackedScene>("res://parts/ConveyorLegCBC.tscn");
@@ -113,12 +123,14 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 
 	protected override void ScaleConveyor(Node3D conveyor, float conveyorLength) {
 		// ConveyorAutomaticLength and conveyorLength have no effect on curved conveyors.
-		conveyor.Scale = new Vector3(Length, 1f, Width / 2f);
+		conveyor.Scale = new Vector3(Length / ConveyorBaseLength, 1f, Width / ConveyorBaseWidth);
 	}
 
 	protected override void ScaleSideGuard(Node3D guard, float guardLength) {
 		// SideGuardsAutoScale and guardLength have no effect on curved side guards.
-		guard.Scale = new Vector3(Length / 2f, 1f, Width / 2f);
+		float curvedSideGuardBaseLength = BaseLength;
+		float curvedSideGuardBaseWidth = BaseWidth;
+		guard.Scale = new Vector3(Length / curvedSideGuardBaseLength, 1f, Width / curvedSideGuardBaseWidth);
 	}
 	#endregion Conveyors and Side Guards
 
@@ -139,7 +151,7 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	}
 
 	protected override void MoveLegStandToPathPosition(Node3D legStand, float position) {
-		float radius = Width / 2f * 1.5f;
+		float radius = Width / BaseWidth * BaseMiddleRadius;
 		float angle = Mathf.DegToRad(position);
 
 		Vector3 newPosition = new Vector3(0, legStand.Position.Y, radius).Rotated(Vector3.Up, angle);

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -150,11 +150,12 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 		return (float) Math.Round(Mathf.RadToDeg(new Vector3(0, 0, 1).SignedAngleTo(position.Slide(Vector3.Up), Vector3.Up)));
 	}
 
-	protected override void MoveLegStandToPathPosition(Node3D legStand, float position) {
-		float radius = Width / BaseWidth * BaseMiddleRadius;
-		float angle = Mathf.DegToRad(position);
+	protected override void MoveLegStandToPathPosition(Node3D legStand, float pathPosition)
+	{
+		float pathRadius = Width / BaseWidth * BaseMiddleRadius;
+		float angle = Mathf.DegToRad(pathPosition);
 
-		Vector3 newPosition = new Vector3(0, legStand.Position.Y, radius).Rotated(Vector3.Up, angle);
+		Vector3 newPosition = new Vector3(0, legStand.Position.Y, pathRadius).Rotated(Vector3.Up, angle);
 		if (legStand.Position != newPosition)
 		{
 			legStand.Position = newPosition;

--- a/src/Assembly/CurvedConveyorAssembly.cs
+++ b/src/Assembly/CurvedConveyorAssembly.cs
@@ -111,7 +111,7 @@ public partial class CurvedConveyorAssembly : ConveyorAssembly
 	}
 
 	#region Conveyors and Side Guards
-	protected override Transform3D LockConveyorsGroup(Transform3D transform) {
+	internal override Transform3D LockConveyorsGroup(Transform3D transform) {
 		// Just don't let it move at all, except Y axis translation.;
 		var scale = transform.Basis.Scale;
 		var position = new Vector3(0, transform.Origin.Y, 0);

--- a/src/Assembly/CurvedConveyorAssemblyLegStands.cs
+++ b/src/Assembly/CurvedConveyorAssemblyLegStands.cs
@@ -11,11 +11,13 @@ public partial class CurvedConveyorAssemblyLegStands : ConveyorAssemblyLegStands
 		// Assume that conveyors and legStands have the same rotation.
 		return (-90f + assembly.AutoLegStandsMarginEnds, 0f - assembly.AutoLegStandsMarginEnds);
 	}
-	protected override void LockLegStandsGroup() {
+	protected override Transform3D LockLegStandsGroup(Transform3D transform) {
 		// We should probably let this rotate around the Y axis, but that would require accounting for legStands rotation in GetLegStandsCoverage().
 		// For now, we won't let it move at all except Y axis translation.
-		this.Rotation = new Vector3(0, 0, 0);
-		this.Position = new Vector3(0, _cachedLegStandsPosition.Y, 0);
+		var scale = transform.Basis.Scale;
+		var rotation = new Vector3(0, 0, 0);
+		var position = new Vector3(0, transform.Origin.Y, 0);
+		return new Transform3D(Basis.FromEuler(rotation).Scaled(scale), position);
 	}
 
 	protected override float GetPositionOnLegStandsPath(Vector3 position) {

--- a/src/Assembly/CurvedConveyorAssemblyLegStands.cs
+++ b/src/Assembly/CurvedConveyorAssemblyLegStands.cs
@@ -1,0 +1,46 @@
+using System;
+using Godot;
+
+[Tool]
+public partial class CurvedConveyorAssemblyLegStands : ConveyorAssemblyLegStands
+{
+	private CurvedConveyorAssembly assembly => GetParentOrNull<CurvedConveyorAssembly>();
+
+	#region Leg Stands
+	protected override (float, float) GetLegStandCoverage() {
+		// Assume that conveyors and legStands have the same rotation.
+		return (-90f + assembly.AutoLegStandsMarginEnds, 0f - assembly.AutoLegStandsMarginEnds);
+	}
+	protected override void LockLegStandsGroup() {
+		// We should probably let this rotate around the Y axis, but that would require accounting for legStands rotation in GetLegStandsCoverage().
+		// For now, we won't let it move at all except Y axis translation.
+		this.Rotation = new Vector3(0, 0, 0);
+		this.Position = new Vector3(0, _cachedLegStandsPosition.Y, 0);
+	}
+
+	protected override float GetPositionOnLegStandsPath(Vector3 position) {
+		return (float) Math.Round(Mathf.RadToDeg(new Vector3(0, 0, 1).SignedAngleTo(position.Slide(Vector3.Up), Vector3.Up)));
+	}
+
+	protected override bool MoveLegStandToPathPosition(Node3D legStand, float pathPosition)
+	{
+		float pathRadius = assembly.MiddleRadius;
+		float angle = Mathf.DegToRad(pathPosition);
+
+		bool changed = false;
+		Vector3 newPosition = new Vector3(0, legStand.Position.Y, pathRadius).Rotated(Vector3.Up, angle);
+		if (legStand.Position != newPosition)
+		{
+			legStand.Position = newPosition;
+			changed = true;
+		}
+		Vector3 newRotation = new Vector3(0f, angle, 0f);
+		if (legStand.Rotation != newRotation)
+		{
+			legStand.Rotation = newRotation;
+			changed = true;
+		}
+		return changed;
+	}
+	#endregion Leg Stands
+}

--- a/src/Assembly/CurvedConveyorAssemblyLegStands.cs
+++ b/src/Assembly/CurvedConveyorAssemblyLegStands.cs
@@ -6,6 +6,12 @@ public partial class CurvedConveyorAssemblyLegStands : ConveyorAssemblyLegStands
 {
 	private CurvedConveyorAssembly assembly => GetParentOrNull<CurvedConveyorAssembly>();
 
+	public override void _Ready()
+	{
+		base._Ready();
+		assembly.ScaleXChanged += void (_) => legStandsPathChanged = true;
+	}
+
 	#region Leg Stands
 	protected override (float, float) GetLegStandCoverage() {
 		// Assume that conveyors and legStands have the same rotation.

--- a/src/Assembly/TransformMonitoredNode3D.cs
+++ b/src/Assembly/TransformMonitoredNode3D.cs
@@ -1,5 +1,6 @@
 using Godot;
 
+[Tool]
 public partial class TransformMonitoredNode3D: Node3D
 {
 	[Signal]

--- a/src/Assembly/TransformMonitoredNode3D.cs
+++ b/src/Assembly/TransformMonitoredNode3D.cs
@@ -1,0 +1,121 @@
+using Godot;
+
+public partial class TransformMonitoredNode3D: Node3D
+{
+	[Signal]
+	public delegate void TransformChangedEventHandler(Transform3D transform);
+
+	[Signal]
+	public delegate void BasisChangedEventHandler(Basis basis);
+
+	[Signal]
+	public delegate void BasisXChangedEventHandler(Vector3 basisX);
+
+	[Signal]
+	public delegate void BasisYChangedEventHandler(Vector3 basisY);
+
+	[Signal]
+	public delegate void BasisZChangedEventHandler(Vector3 basisZ);
+
+	[Signal]
+	public delegate void ScaleChangedEventHandler(Vector3 scale);
+
+	[Signal]
+	public delegate void ScaleXChangedEventHandler(float scaleX);
+
+	[Signal]
+	public delegate void ScaleYChangedEventHandler(float scaleY);
+
+	[Signal]
+	public delegate void ScaleZChangedEventHandler(float scaleZ);
+
+	[Signal]
+	public delegate void PositionChangedEventHandler(Vector3 position);
+
+	[Signal]
+	public delegate void PositionXChangedEventHandler(float positionX);
+
+	[Signal]
+	public delegate void PositionYChangedEventHandler(float positionY);
+
+	[Signal]
+	public delegate void PositionZChangedEventHandler(float positionZ);
+
+	private Transform3D _transformPrev = Transform3D.Identity;
+	private Basis _basisPrev = Basis.Identity;
+	private Vector3 _scalePrev = Vector3.One;
+	private Vector3 _positionPrev = Vector3.Zero;
+
+	public TransformMonitoredNode3D()
+	{
+		SetNotifyLocalTransform(true);
+	}
+
+	public override void _Notification(int what)
+	{
+		if (what == NotificationLocalTransformChanged)
+		{
+			OnTransformSet(Transform);
+		}
+		base._Notification(what);
+	}
+
+	private void OnTransformSet(Transform3D transform)
+	{
+		// Assume transformPrev is already properly constrained
+		bool changed = transform != _transformPrev;
+		if (!changed) return;
+		Transform3D constrainedTransform = ConstrainTransform(transform);
+		bool constrained = constrainedTransform != transform;
+		bool actuallyChanged = constrainedTransform != _transformPrev;
+		if (constrained)
+		{
+			// Assigning to Transform will immediately call this method again,
+			// but it will do nothing if we update transformPrev first.
+			_transformPrev = constrainedTransform;
+			Transform = constrainedTransform;
+		}
+		if (actuallyChanged)
+		{
+			_transformPrev = constrainedTransform;
+			_OnTransformChanged(constrainedTransform);
+		}
+	}
+
+	private void _OnTransformChanged(Transform3D transform)
+	{
+		bool basisChanged = transform.Basis != _basisPrev;
+		bool basisXChanged = transform.Basis.X != _basisPrev.X;
+		bool basisYChanged = transform.Basis.Y != _basisPrev.Y;
+		bool basisZChanged = transform.Basis.Z != _basisPrev.Z;
+		_basisPrev = transform.Basis;
+		bool scaleChanged = transform.Basis.Scale != _scalePrev;
+		bool scaleXChanged = transform.Basis.Scale.X != _scalePrev.X;
+		bool scaleYChanged = transform.Basis.Scale.Y != _scalePrev.Y;
+		bool scaleZChanged = transform.Basis.Scale.Z != _scalePrev.Z;
+		_scalePrev = transform.Basis.Scale;
+		bool positionChanged = transform.Origin != _positionPrev;
+		bool positionXChanged = transform.Origin.X != _positionPrev.X;
+		bool positionYChanged = transform.Origin.Y != _positionPrev.Y;
+		bool positionZChanged = transform.Origin.Z != _positionPrev.Z;
+		_positionPrev = transform.Origin;
+		OnTransformChanged(transform);
+		if (basisChanged) OnBasisChanged(transform.Basis);
+		if (basisXChanged) OnBasisXChanged(transform.Basis.X);
+		if (basisYChanged) OnBasisYChanged(transform.Basis.Y);
+		if (basisZChanged) OnBasisZChanged(transform.Basis.Z);
+		if (scaleChanged) OnScaleChanged(transform.Basis.Scale);
+		if (scaleXChanged) OnScaleXChanged(transform.Basis.Scale.X);
+		if (scaleYChanged) OnScaleYChanged(transform.Basis.Scale.Y);
+		if (scaleZChanged) OnScaleZChanged(transform.Basis.Scale.Z);
+		if (positionChanged) OnPositionChanged(transform.Origin);
+		if (positionXChanged) OnPositionXChanged(transform.Origin.X);
+		if (positionYChanged) OnPositionYChanged(transform.Origin.Y);
+		if (positionZChanged) OnPositionZChanged(transform.Origin.Z);
+	}
+
+	protected virtual Transform3D ConstrainTransform(Transform3D transform)
+	{
+		return transform;
+	}
+}

--- a/src/ConveyorLeg/ConveyorLeg.cs
+++ b/src/ConveyorLeg/ConveyorLeg.cs
@@ -69,8 +69,8 @@ public partial class ConveyorLeg : Node3D
 		if (legsSidesMaterial != null)
 			legsSidesMaterial.SetShaderParameter("Scale", Scale.Y);
 
-		if (legsBars != null && legsBars.ParentScale != Scale.Y)
-			legsBars.ParentScale = Scale.Y;
+		if (legsBars != null && legsBars.ParentScale != Scale)
+			legsBars.ParentScale = Scale;
 
 		foreach (Node3D end in ends.GetChildren())
 		{

--- a/src/ConveyorLeg/ConveyorLeg.cs
+++ b/src/ConveyorLeg/ConveyorLeg.cs
@@ -15,6 +15,7 @@ public partial class ConveyorLeg : Node3D
 		set
 		{
 			grabsRotation = value;
+			SetPhysicsProcess(true);
 		}
 	}
 
@@ -45,6 +46,8 @@ public partial class ConveyorLeg : Node3D
 		legsSidesMesh1.Mesh.SurfaceSetMaterial(0, legsSidesMaterial);
 		legsBars = GetNode<LegBars>("LegsBars");
 		ends = GetNode<Node3D>("Ends");
+
+		SetNotifyLocalTransform(true);
 	}
 
 	public override void _Process(double delta)
@@ -60,6 +63,7 @@ public partial class ConveyorLeg : Node3D
 		{
 			Scale = new Vector3(1, nodeScaleY, nodeScaleZ);
 		}
+		SetProcess(false);
 	}
 
 	public override void _PhysicsProcess(double delta)
@@ -87,5 +91,15 @@ public partial class ConveyorLeg : Node3D
 		grab2.Scale = Vector3.One;
 
 		prevScale = Scale;
+		SetPhysicsProcess(false);
+	}
+
+	public override void _Notification(int what)
+	{
+		if (what == NotificationLocalTransformChanged)
+		{
+			SetProcess(true);
+			SetPhysicsProcess(true);
+		}
 	}
 }

--- a/src/ConveyorLeg/LegBars.cs
+++ b/src/ConveyorLeg/LegBars.cs
@@ -73,7 +73,9 @@ public partial class LegBars : Node3D
 
 	void RemoveBar()
 	{
-		GetChild(GetChildCount() - 1).QueueFree();
+		var child = GetChild(GetChildCount() - 1);
+		child.QueueFree();
+		RemoveChild(child);
 	}
 
 	void FixBars()

--- a/src/ConveyorLeg/LegBars.cs
+++ b/src/ConveyorLeg/LegBars.cs
@@ -31,6 +31,7 @@ public partial class LegBars : Node3D
 			}
 
 			parentScale = value;
+			SetProcess(true);
 		}
 	}
 
@@ -60,6 +61,7 @@ public partial class LegBars : Node3D
 
 			prevScale = ParentScale;
 		}
+		SetProcess(false);
 	}
 
 	void SpawnBar()

--- a/src/ConveyorLeg/LegBars.cs
+++ b/src/ConveyorLeg/LegBars.cs
@@ -8,9 +8,9 @@ public partial class LegBars : Node3D
 	PackedScene legsBarScene;
 
 	float barsDistance = 1.0f;
-	float parentScale = 1.0f;
+	Vector3 parentScale = Vector3.One;
 	[Export]
-	public float ParentScale
+	public Vector3 ParentScale
 	{
 		get
 		{
@@ -18,7 +18,7 @@ public partial class LegBars : Node3D
 		}
 		set
 		{
-			int roundedScale = Mathf.FloorToInt(value) + 1;
+			int roundedScale = Mathf.FloorToInt(value.Y) + 1;
 			int barsCount = GetChildCount();
 
 			for (; roundedScale - 1 > barsCount && roundedScale != 0; barsCount++)
@@ -50,15 +50,15 @@ public partial class LegBars : Node3D
 	{
 		if (owner != null)
 		{
-			if (owner.Scale == prevScale) return;
+			if (ParentScale == prevScale) return;
 
-			Vector3 newScale = new(1 / owner.Scale.X, 1 / owner.Scale.Y, 1);
+			Vector3 newScale = new(1 / ParentScale.X, 1 / ParentScale.Y, 1);
 			if(Scale != newScale)
 			{
-				Scale = new Vector3(1 / owner.Scale.X, 1 / owner.Scale.Y, 1);
+				Scale = new Vector3(1 / ParentScale.X, 1 / ParentScale.Y, 1);
 			}
 
-			prevScale = owner.Scale;
+			prevScale = ParentScale;
 		}
 	}
 

--- a/src/Util/NodeExtensions.cs
+++ b/src/Util/NodeExtensions.cs
@@ -8,8 +8,15 @@ public static class NodeExtensions
 		return GodotObject.IsInstanceValid(target) ? target : null;
 	}
 
+	public static void CacheValidNodeOrNull<T>(this Node node, NodePath path, ref T cachedReference) where T : Node
+	{
+		if (GodotObject.IsInstanceValid(cachedReference)) return;
+		cachedReference = node.GetValidNodeOrNull<T>(path);
+	}
+
 	public static T GetCachedValidNodeOrNull<T>(this Node node, NodePath path, ref T cachedReference) where T : Node
 	{
-		return GodotObject.IsInstanceValid(cachedReference) ? cachedReference : GodotObject.IsInstanceValid(cachedReference = node.GetNodeOrNull<T>(path)) ? cachedReference : null;
+		CacheValidNodeOrNull(node, path, ref cachedReference);
+		return cachedReference;
 	}
 }

--- a/src/Util/NodeExtensions.cs
+++ b/src/Util/NodeExtensions.cs
@@ -1,0 +1,15 @@
+using Godot;
+
+public static class NodeExtensions
+{
+	public static T GetValidNodeOrNull<T>(this Node node, NodePath path) where T : Node
+	{
+		T target = node.GetNodeOrNull<T>(path);
+		return GodotObject.IsInstanceValid(target) ? target : null;
+	}
+
+	public static T GetCachedValidNodeOrNull<T>(this Node node, NodePath path, ref T cachedReference) where T : Node
+	{
+		return GodotObject.IsInstanceValid(cachedReference) ? cachedReference : GodotObject.IsInstanceValid(cachedReference = node.GetNodeOrNull<T>(path)) ? cachedReference : null;
+	}
+}


### PR DESCRIPTION
The goal of this PR is to improve the performance of `ConveyorAssembly` by avoiding as much work in `_Process` and `_PhysicsProcess` as possible. Also includes some refactoring.

This moves detecting Transform changes to signals. That way, things that depend on Transform can update immediately instead of waiting for `_Process` or `_PhysicsProcess`. Also, this monitoring includes a constraint step (for minimum or fixed scale, etc). Constraining a transform happens before change detection. So, if something attempts to change a transform, but the constraining logic reverts the change, no signal is fired. This logic is reusable by extending `TransformMonitoredNode3D`.

The file `ConveyorAssembly.LegStands.cs` was converted into its own class `ConveyorAssemblyLegStands`. It was formerly a partial declaration for the leg stands functionality within `ConveyorAssembly`. It's a script attached to the LegStands child node responsible for all of the auto-generated leg stands.

The class `ConveyorAssemblyConveyors` was created. All of the code in `ConveyorAssembly.Conveyors.cs` will eventually move there, but for now, only the minimum has moved. It's a script attached to the Conveyors child node that's responsible for constraining its transform and calling `UpdateConveyors`.

For `UpdateLegStands`, the initial approach was to track dependencies and only call the methods whose dependencies had changed. This was tedious and the performance benefit became negligible once I was skipping top-level methods (the callers). Still, I left those changes in since they still help performance while actively adjusting assemblies, but they should probably be removed for readability anyway.

Ultimately, I realized we could keep `_PhysicsProcess` and only enable it when it is needed. That way, we can avoid calling it continuously but still centralize our tightly-coupled update logic in a single place. Every call to `_PhysicsProcess` disables it for future frames. Whenever a dependency is updated, we reenable the appropriate node's `_PhysicsProcess` so it can run `UpdateConveyors` or `UpdateLegStands` only as needed.

I went ahead and applied the same process-skipping optimization in `ConveyorLeg` and `LegBars`. It's simple enough we should apply it everywhere we can.

Fixes #70.

Supersedes: https://github.com/Open-Industry-Project/Open-Industry-Project/pull/103