### PR TITLE
Fix regression: auto-generated leg stands spawning with the wrong width

### DIFF
--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -360,14 +360,19 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 	}
 
 	private void UpdateAllLegStandsWidth() {
-		float targetWidth = GetLegStandTargetWidth();
 		foreach (Node child in GetChildren()) {
 			ConveyorLeg legStand = child as ConveyorLeg;
 			if (legStand == null) {
 				continue;
 			}
-			legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / LegStandsBaseWidth);
+			UpdateLegStandWidth(legStand);
 		}
+	}
+
+	private void UpdateLegStandWidth(Node3D legStand)
+	{
+		float targetWidth = GetLegStandTargetWidth();
+		legStand.Scale = new Vector3(1f, legStand.Scale.Y, targetWidth / LegStandsBaseWidth);
 	}
 
 	private float GetLegStandTargetWidth() {

--- a/src/Assembly/ConveyorAssemblyLegStands.cs
+++ b/src/Assembly/ConveyorAssemblyLegStands.cs
@@ -624,6 +624,7 @@ public partial class ConveyorAssemblyLegStands : ConveyorAssemblyChild
 		};
 		ConveyorLeg legStand = AddOrGetLegStandInstance(name) as ConveyorLeg;
 		MoveLegStandToPathPosition(legStand, position);
+		UpdateLegStandWidth(legStand);
 
 		// It probably doesn't matter, but let's try to keep leg stands in order.
 		int trueIndex = (LegIndex) index switch {


### PR DESCRIPTION
Fixes regression from #103.

Leg stands spawn with the correct width now.

Before, they did not, but this wasn't apparent because the incorrect width would get fixed next frame by UpdateLegStands. Now that we've optimized-away unnecessary calls to UpdateLegStands, we need to do this properly.