### PR TITLE
Allow tighter ChainTransfer spacing

### DIFF
--- a/src/ChainTransfer/Base.tscn
+++ b/src/ChainTransfer/Base.tscn
@@ -183,7 +183,7 @@ shadow_mesh = SubResource("ArrayMesh_d2c3f")
 friction = 0.5
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_8d0fv"]
-size = Vector3(2, 0.0369148, 0.0341797)
+size = Vector3(2, 0.0369148, 0.03)
 
 [sub_resource type="ArrayMesh" id="ArrayMesh_rn4p6"]
 _surfaces = [{

--- a/src/ChainTransfer/ChainTransfer.cs
+++ b/src/ChainTransfer/ChainTransfer.cs
@@ -56,7 +56,7 @@ public partial class ChainTransfer : Node3D
 	}
 
 	float distance = 0.33f;
-	[Export] float Distance
+	[Export(PropertyHint.Range, "0.25,1,or_less,or_greater,suffix: m")] float Distance
 	{
 		get
 		{
@@ -64,7 +64,7 @@ public partial class ChainTransfer : Node3D
 		}
 		set
 		{
-			distance = Mathf.Clamp(value, 0.25f, 5.0f);
+			distance = Mathf.Clamp(value, 0.03f, 5.0f);
 			SetChainsDistance(distance);
 		}
 	}


### PR DESCRIPTION
Distance between chains can now be reduced to 3cm (previously 25cm).

3cm is the width of a physical chain, so a 3cm Distance is the smallest possible without overlapping them.

The PropertyHint slider still uses 25cm as the minimum (the distance where the container models touch), but the user can type in a smaller number.

Closes #81.