### PR TITLE
Reset the transform of `Box` and `Pallet` instead of just position. 

### DIFF
--- a/src/Box/Box.cs
+++ b/src/Box/Box.cs
@@ -4,10 +4,10 @@ using Godot;
 public partial class Box : Node3D
 {
 	RigidBody3D rigidBody;
-	Vector3 initialPos;
+	Transform3D initialTransform;
 	public bool instanced = false;
 	bool _paused = false;
-	bool enable_inital_pos = false;
+	bool enable_inital_transform = false;
 
 	Root Main;
 	public override void _Ready()
@@ -81,10 +81,10 @@ public partial class Box : Node3D
 	{
 		if (Main == null) return;
 
-		initialPos = GlobalPosition;
+		initialTransform = GlobalTransform;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
-		enable_inital_pos = true;
+		enable_inital_transform = true;
 	}
 
 	void OnSimulationEnded()
@@ -100,20 +100,17 @@ public partial class Box : Node3D
 		{
 			rigidBody.TopLevel = false;
 
-			rigidBody.Position = Vector3.Zero;
-			rigidBody.Rotation = Vector3.Zero;
-			rigidBody.Scale = Vector3.One;
+			rigidBody.Transform = Transform3D.Identity;
 
 			rigidBody.LinearVelocity = Vector3.Zero;
 			rigidBody.AngularVelocity = Vector3.Zero;
 
 			//Work around for #83 
-			if (enable_inital_pos)
+			if (enable_inital_transform)
 			{
-				GlobalPosition = initialPos;
+				GlobalTransform = initialTransform;
 			}
 
-			Rotation = Vector3.Zero;
 		}
 	}
 

--- a/src/Pallet/Pallet.cs
+++ b/src/Pallet/Pallet.cs
@@ -4,10 +4,10 @@ using Godot;
 public partial class Pallet : Node3D
 {
 	RigidBody3D rigidBody;
-	Vector3 initialPos;
+	Transform3D initialTransform;
 	public bool instanced = false;
 	bool _paused = false;
-	bool enable_inital_pos = false;
+	bool enable_inital_transform = false;
 
 	Root Main;
 
@@ -82,10 +82,10 @@ public partial class Pallet : Node3D
 	{
 		if (Owner == null) return;
 
-		initialPos = GlobalPosition;
+		initialTransform = GlobalTransform;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
-		enable_inital_pos = true;
+		enable_inital_transform = true;
 	}
 
 	void OnSimulationEnded()
@@ -101,20 +101,17 @@ public partial class Pallet : Node3D
 		{
 			rigidBody.TopLevel = false;
 
-			rigidBody.Position = Vector3.Zero;
-			rigidBody.Rotation = Vector3.Zero;
-			rigidBody.Scale = Vector3.One;
+			rigidBody.Transform = Transform3D.Identity;
 
 			rigidBody.LinearVelocity = Vector3.Zero;
 			rigidBody.AngularVelocity = Vector3.Zero;
 
 			//Work around for #83 
-			if (enable_inital_pos)
+			if (enable_inital_transform)
 			{
-				GlobalPosition = initialPos;
+				GlobalTransform = initialTransform;
 			}
 
-			Rotation = Vector3.Zero;
 		}
 	}
 


### PR DESCRIPTION
Remove the redundant line **Rotation = Vector3.Zero;** in **Box.cs**. 

The rotation is already reset using **rigidBody.Rotation = Vector3.Zero;** earlier in the method. This simplifies the code and avoids confusion.

![image](https://github.com/user-attachments/assets/c3390c09-c278-44a9-a292-b4df52ba9058)

