### PR TITLE
Expose conveyor part's PhysicsMaterial in the inspector

### DIFF
--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -253,6 +253,29 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		}
 	}
 
+	[Export]
+	public PhysicsMaterial BeltConveyorBeltPhysicsMaterial {
+		get
+		{
+			IBeltConveyor conveyor = conveyors?.GetChildOrNull<IBeltConveyor>(0);
+			return conveyor?.BeltPhysicsMaterial;
+		}
+		set
+		{
+			if (conveyors == null)
+			{
+				return;
+			}
+			foreach (Node node in conveyors.GetChildren())
+			{
+				if (node is IBeltConveyor conveyor)
+				{
+					conveyor.BeltPhysicsMaterial = value;
+				}
+			}
+		}
+	}
+
 	[ExportSubgroup("RollerConveyor", "RollerConveyor")]
 	[Export(PropertyHint.None, "suffix:m/s")]
 	public float RollerConveyorSpeed {
@@ -578,7 +601,8 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		// Only show if a IBeltConveyor is present.
 		else if (propertyName == PropertyName.BeltConveyorBeltColor
 			|| propertyName == PropertyName.BeltConveyorBeltTexture
-			|| propertyName == PropertyName.BeltConveyorSpeed) {
+			|| propertyName == PropertyName.BeltConveyorSpeed
+			|| propertyName == PropertyName.BeltConveyorBeltPhysicsMaterial) {
 			property["usage"] = (int)(conveyors?.GetChildOrNull<IBeltConveyor>(0) != null ? PropertyUsageFlags.Default : PropertyUsageFlags.NoEditor);
 		}
 		// Only show if a IRollerConveyor is present.

--- a/src/Conveyor/BeltConveyor.cs
+++ b/src/Conveyor/BeltConveyor.cs
@@ -82,6 +82,18 @@ public partial class BeltConveyor : Node3D, IBeltConveyor
 	}
 	private float _speed;
 
+	[Export]
+	public PhysicsMaterial BeltPhysicsMaterial
+	{
+		get => GetNode<StaticBody3D>("StaticBody3D")?.PhysicsMaterialOverride;
+		set
+		{
+			GetNode<StaticBody3D>("StaticBody3D")?.SetPhysicsMaterialOverride(value);
+			GetNode<StaticBody3D>("ConveyorEnd/StaticBody3D")?.SetPhysicsMaterialOverride(value);
+			GetNode<StaticBody3D>("ConveyorEnd2/StaticBody3D")?.SetPhysicsMaterialOverride(value);
+		}
+	}
+
 	readonly Guid id = Guid.NewGuid();
 	double scan_interval = 0;
 	bool readSuccessful = false;
@@ -134,6 +146,9 @@ public partial class BeltConveyor : Node3D, IBeltConveyor
 
 		conveyorEnd1.Speed = Speed;
 		conveyorEnd2.Speed = Speed;
+
+		conveyorEnd1.GetNode<StaticBody3D>("StaticBody3D").PhysicsMaterialOverride = sb.PhysicsMaterialOverride;
+		conveyorEnd2.GetNode<StaticBody3D>("StaticBody3D").PhysicsMaterialOverride = sb.PhysicsMaterialOverride;
 	}
 
 	public override void _EnterTree()

--- a/src/Conveyor/CurvedBeltConveyor.cs
+++ b/src/Conveyor/CurvedBeltConveyor.cs
@@ -101,6 +101,18 @@ public partial class CurvedBeltConveyor : Node3D, IBeltConveyor
 	}
 	private float _referenceDistance = 0.5f; // Assumes a 1m wide package.
 
+	[Export]
+	public PhysicsMaterial BeltPhysicsMaterial
+	{
+		get => GetNode<StaticBody3D>("StaticBody3D")?.PhysicsMaterialOverride;
+		set
+		{
+			GetNode<StaticBody3D>("StaticBody3D")?.SetPhysicsMaterialOverride(value);
+			GetNode<StaticBody3D>("ConveyorEnd/StaticBody3D")?.SetPhysicsMaterialOverride(value);
+			GetNode<StaticBody3D>("ConveyorEnd2/StaticBody3D")?.SetPhysicsMaterialOverride(value);
+		}
+	}
+
 	StaticBody3D sb;
 	MeshInstance3D mesh;
 	Material beltMaterial;
@@ -174,6 +186,9 @@ public partial class CurvedBeltConveyor : Node3D, IBeltConveyor
 
 		conveyorEnd1.Speed = LinearSpeed;
 		conveyorEnd2.Speed = LinearSpeed;
+
+		conveyorEnd1.GetNode<StaticBody3D>("StaticBody3D").PhysicsMaterialOverride = sb.PhysicsMaterialOverride;
+		conveyorEnd2.GetNode<StaticBody3D>("StaticBody3D").PhysicsMaterialOverride = sb.PhysicsMaterialOverride;
 
 		prevScaleX = Scale.X;
 	}

--- a/src/Conveyor/IBeltConveyor.cs
+++ b/src/Conveyor/IBeltConveyor.cs
@@ -10,4 +10,5 @@ public interface IBeltConveyor: IConveyor, IComms
 
 	Color BeltColor { get; set; }
 	ConvTexture BeltTexture { get; set; }
+	PhysicsMaterial BeltPhysicsMaterial { get; set; }
 }


### PR DESCRIPTION
Allows changing friction without enabling editable children. The values will be read-only at first, so you'll need to make-unique the resource or assign a new one.

Known issue:
- For assemblies, Godot will save the PhysicsMaterial resource to the current scene even if you didn't change it from its defaults. If the defaults change in the conveyor part's scene, this will cause the scene containing the assembly to be out of sync with that.

Closes #108 