### PR TITLE
Fix failure to unload .NET assemblies

### DIFF
--- a/src/Main/Root.cs
+++ b/src/Main/Root.cs
@@ -488,12 +488,16 @@ public partial class Root : Node3D
 
 	public override void _EnterTree()
 	{
-		EditorInterface.Singleton.GetSelection().SelectionChanged += OnSelectionChanged;
+		EditorInterface.Singleton.GetSelection().Connect(EditorSelection.SignalName.SelectionChanged, new Callable(this, MethodName.OnSelectionChanged));
 	}
 
 	public override void _ExitTree()
 	{
-		EditorInterface.Singleton.GetSelection().SelectionChanged -= OnSelectionChanged;
+		var selection = EditorInterface.Singleton.GetSelection();
+		var signalName = EditorSelection.SignalName.SelectionChanged;
+		var callable = new Callable(this, MethodName.OnSelectionChanged);
+		if (!selection.IsConnected(signalName, callable)) return;
+		selection.Disconnect(signalName, callable);
 	}
 
 	public void OnSelectionChanged()


### PR DESCRIPTION
Occasionally, rebuilding the project would display the error message ".NET: Failed to unload assemblies." and the project would need to be reloaded to continue.

Apparently, Godot was trying to serialize a delegate subscribed to the `OnSelectionChanged` event. The target of the delegate was a method on Main, a Node instance which had been disposed. When Godot looked up Main's instance id, the lookup method discovered that Main had been disposed and threw an `ObjectDisposedException`. This caused the entire assembly reload to fail.

It seems like throwing the exception may have been a preventative measure. In any case, the whole problem can be avoided by not storing a delegate at all.

This commit replaces the event subscription with an equivalent Godot signal connection. Instead of a delegate, a Godot Callable is used. The syntax is uglier, but it lets Godot manage disconnecting the signal for us.

I found more info on this problem here: https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_signals.html