### PR TITLE
Cleanup conveyor interfaces

### DIFF
--- a/src/Assembly/ConveyorArray.cs
+++ b/src/Assembly/ConveyorArray.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Godot;
 
 [Tool]
-public partial class ConveyorArray : Node3D, IComms
+public partial class ConveyorArray : Node3D, IConveyor
 {
 	[Export(PropertyHint.None, "suffix:m")]
 	public float Width { get => _width; set => SetProcessIfChanged(ref _width, value); }

--- a/src/Assembly/ConveyorAssembly.Conveyors.cs
+++ b/src/Assembly/ConveyorAssembly.Conveyors.cs
@@ -149,7 +149,7 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D
 	}
 
 	internal static bool IsConveyor(Node node) {
-		return node as IConveyor != null || node as IBeltConveyor != null || node as IRollerConveyor != null;
+		return node as IConveyor != null;
 	}
 
 	protected virtual void ScaleConveyor(Node3D conveyor, float conveyorLength, float conveyorWidth) {

--- a/src/Assembly/ConveyorAssembly.cs
+++ b/src/Assembly/ConveyorAssembly.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 
 [Tool]
-public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
+public partial class ConveyorAssembly : TransformMonitoredNode3D, IConveyor
 {
 	#region Constants
 	protected virtual float BaseLength => 1f;
@@ -70,6 +70,14 @@ public partial class ConveyorAssembly : TransformMonitoredNode3D, IComms
 		}
 	}
 	private bool _conveyorAutomaticLength = true;
+
+
+	public float Speed { get => BeltConveyorSpeed; set
+		{
+			BeltConveyorSpeed = value;
+			RollerConveyorSpeed = value;
+		}
+	}
 
 	// This rest of this section is for properties proxied to the conveyor parts.
 	[ExportSubgroup("Comms")]

--- a/src/Conveyor/ConveyorEnd.cs
+++ b/src/Conveyor/ConveyorEnd.cs
@@ -13,7 +13,7 @@ public partial class ConveyorEnd : Node3D
 	public ShaderMaterial beltMaterial;
 	Shader beltShader;
 
-	IConveyor owner;
+	BeltConveyor owner;
 	Root main;
 
 	float prevScaleX;
@@ -29,7 +29,8 @@ public partial class ConveyorEnd : Node3D
 		beltShader = beltMaterial.Shader.Duplicate() as Shader;
 		beltMaterial.Shader = beltShader;
 
-		owner = Owner as IConveyor;
+		owner = Owner as BeltConveyor;
+		main = GetTree().EditedSceneRoot as Root;
 	}
 
 	public override void _Process(double delta)
@@ -49,9 +50,9 @@ public partial class ConveyorEnd : Node3D
 		{
 			RemakeMesh(owner);
 
-			if (owner.Main == null) return;
+			if (main == null) return;
 
-			if (owner.Main.Start)
+			if (main.Start)
 			{
 				Vector3 localFront = -GlobalTransform.Basis.Z.Normalized();
 				if (!owner.Main.simulationPaused)

--- a/src/Conveyor/IBeltConveyor.cs
+++ b/src/Conveyor/IBeltConveyor.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-public interface IBeltConveyor: IConveyor, IComms
+public interface IBeltConveyor: IConveyor
 {
 	public enum ConvTexture
 	{

--- a/src/Conveyor/IConveyor.cs
+++ b/src/Conveyor/IConveyor.cs
@@ -4,4 +4,5 @@ using System;
 public interface IConveyor : IComms
 {
 	public float Speed { get; set; }
+	public Node3D AsNode3D() { return this as Node3D; }
 }

--- a/src/Conveyor/IConveyor.cs
+++ b/src/Conveyor/IConveyor.cs
@@ -4,7 +4,4 @@ using System;
 public interface IConveyor
 {
 	public float Speed { get; set; }
-	public Root Main { get; set; }
-	public Transform3D GlobalTransform { get; set; }
-	public Vector3 Scale { get; set; }
 }

--- a/src/Conveyor/IConveyor.cs
+++ b/src/Conveyor/IConveyor.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-public interface IConveyor
+public interface IConveyor : IComms
 {
 	public float Speed { get; set; }
 }

--- a/src/RollerConveyor/IRollerConveyor.cs
+++ b/src/RollerConveyor/IRollerConveyor.cs
@@ -1,4 +1,3 @@
-public interface IRollerConveyor: IComms
+public interface IRollerConveyor: IConveyor
 {
-	float Speed { get; set; }
 }


### PR DESCRIPTION
Make more conveyor types implement IConveyor, not just BeltConveyors.

Add an AsNode3D method to make getting self as a Node easier. (IConveyor can't just inherit from Node3D because the latter isn't an interface.) This adds the soft requirement that all IConveyors extend Node3D, which they typically do anyway.

Removes properties that also exist in Node3D. Just use AsNode3D to cast instead.