### PR TITLE
Add Box initial velocity property

### DIFF
--- a/src/Box/Box.cs
+++ b/src/Box/Box.cs
@@ -3,6 +3,7 @@ using Godot;
 [Tool]
 public partial class Box : Node3D
 {
+	[Export] public Vector3 InitialLinearVelocity = Vector3.Zero;
 	RigidBody3D rigidBody;
 	Transform3D initialTransform;
 	public bool instanced = false;
@@ -82,6 +83,7 @@ public partial class Box : Node3D
 		if (Main == null) return;
 
 		initialTransform = GlobalTransform;
+		rigidBody.LinearVelocity = InitialLinearVelocity;
 		rigidBody.TopLevel = true;
 		rigidBody.Freeze = false;
 		enable_inital_transform = true;

--- a/src/Box/Box.cs
+++ b/src/Box/Box.cs
@@ -17,12 +17,13 @@ public partial class Box : Node3D
 
 		if (Main != null)
 		{
+			rigidBody.Freeze = !Main.simulationRunning;
+
 			if (Main.simulationRunning)
 			{
 				instanced = true;
+				rigidBody.LinearVelocity = InitialLinearVelocity;
 			}
-
-			rigidBody.Freeze = !Main.simulationRunning;
 		}
 	}
 

--- a/src/BoxSpawner/BoxSpawner.cs
+++ b/src/BoxSpawner/BoxSpawner.cs
@@ -24,6 +24,8 @@ public partial class BoxSpawner : Node3D
 	[Export]
 	public Vector2 spawnRandomSize = new(0.5f, 1f);
 	[Export]
+	public Vector3 SpawnInitialLinearVeclocity = new(0, 0, 0);
+	[Export]
 	public float spawnInterval = 1f;
 
 	private float scan_interval = 0;
@@ -100,6 +102,7 @@ public partial class BoxSpawner : Node3D
 
 		box.Rotation = _rotation;
 		box.Position = _position;
+		box.InitialLinearVelocity = SpawnInitialLinearVeclocity;
 		box.instanced = true;
 
 		AddChild(box, forceReadableName:true);


### PR DESCRIPTION
Add a property to set Box velocity on simulation start and on spawn.

With some configuration, Boxes can start the simulation with the same velocity as the conveyors that will carry them.