### PR TITLE
Fix regression where pre-existing rollers don't spin

### DIFF
--- a/src/RollerConveyor/AbstractRollerContainer.cs
+++ b/src/RollerConveyor/AbstractRollerContainer.cs
@@ -29,16 +29,7 @@ public abstract partial class AbstractRollerContainer : Node3D
 		RollerRemoved += HandleRollerRemoved;
 	}
 
-	public override void _Notification(int what)
-	{
-		if (what == NotificationSceneInstantiated)
-		{
-			OnSceneInstantiated();
-		}
-		base._Notification(what);
-	}
-
-	protected virtual void OnSceneInstantiated()
+	internal virtual void SetupExistingRollers()
 	{
 		foreach (Roller roller in GetRollers())
 		{

--- a/src/RollerConveyor/RollerConveyor.cs
+++ b/src/RollerConveyor/RollerConveyor.cs
@@ -195,18 +195,17 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 		rollers = GetNodeOrNull<Rollers>("Rollers");
 		ends = GetNodeOrNull<Node3D>("Ends");
 
-		// Rollers isn't an instance, so it can't receive NotificationSceneInstantiated.
-		// We'll let it piggyback on our notification instead.
-		rollers.OnSceneInstantiated();
-
 		SetupRollerContainer(rollers);
 		foreach (RollerConveyorEnd end in ends.GetChildren())
 		{
 			SetupRollerContainer(end);
 		}
+
+		// In case transform was changed before scene was instantiated somehow.
 		UpdateScale();
 		UpdateWidth();
 		UpdateLength();
+		UpdateSize();
 	}
 
 	void OnSimulationStarted()
@@ -244,6 +243,8 @@ public partial class RollerConveyor : Node3D, IRollerConveyor
 		ScaleChanged += rollers.OnOwnerScaleChanged;
 		WidthChanged += rollers.SetWidth;
 		LengthChanged += rollers.SetLength;
+
+		rollers.SetupExistingRollers();
 
 		rollers.SetRollerSkewAngle(skewAngle);
 		rollers.OnOwnerScaleChanged(Scale);

--- a/src/RollerConveyor/RollerConveyorEnd.cs
+++ b/src/RollerConveyor/RollerConveyorEnd.cs
@@ -21,10 +21,10 @@ public partial class RollerConveyorEnd : AbstractRollerContainer
 		WidthChanged += SetEndsSeparation;
 	}
 
-	protected override void OnSceneInstantiated()
+	internal override void SetupExistingRollers()
 	{
 		roller = GetNode<Roller>("Roller");
-		base.OnSceneInstantiated();
+		base.SetupExistingRollers();
 	}
 
 	~RollerConveyorEnd()

--- a/src/RollerConveyor/Rollers.cs
+++ b/src/RollerConveyor/Rollers.cs
@@ -13,11 +13,6 @@ public partial class Rollers : AbstractRollerContainer
 		LengthChanged += AddOrRemoveRollers;
 	}
 
-	public new void OnSceneInstantiated()
-	{
-		base.OnSceneInstantiated();
-	}
-
 	private void AddOrRemoveRollers(float conveyorLength)
 	{
 		int roundedLength = Mathf.RoundToInt(conveyorLength / rollersDistance) + 1;


### PR DESCRIPTION
Regression introduced in fe1a63b1.

We were tying to emit `RollerAdded` and `RollerRemoved` before all the signals were connected, specifically `OnRollerAdded` which sets up connections to `SetSpeed`.