### PR TITLE
Add ability to spawn character to free fly location and vice-versa

### DIFF
--- a/addons/fpc/character.gd
+++ b/addons/fpc/character.gd
@@ -161,6 +161,12 @@ func change_reticle(reticle): # Yup, this function is kinda strange
 func _physics_process(delta):
 	if get_tree().edited_scene_root == self:
 		return
+	
+	var forward = -global_transform.basis.z
+	var flat_forward = Vector3(forward.x, 0, forward.z).normalized()
+	var target_basis = Basis().looking_at(flat_forward, Vector3.UP)
+	global_transform.basis = global_transform.basis.slerp(target_basis, 3.0 * delta)
+	
 	# Big thanks to github.com/LorenzoAncora for the concept of the improved debug values
 	current_speed = Vector3.ZERO.distance_to(get_real_velocity())
 	var cv : Vector3 = get_real_velocity()
@@ -221,8 +227,9 @@ func handle_jumping():
 
 
 func handle_movement(delta, input_dir):
-	var direction = input_dir.rotated(-HEAD.rotation.y)
-	direction = Vector3(direction.x, 0, direction.y)
+	var forward = HEAD.global_transform.basis.z
+	var right = HEAD.global_transform.basis.x
+	var direction = (right * input_dir.x + forward * input_dir.y).normalized()
 	move_and_slide()
 	
 	if in_air_momentum:

--- a/addons/fpc/character.gd
+++ b/addons/fpc/character.gd
@@ -341,7 +341,7 @@ func update_camera_fov():
 	if state == "sprinting":
 		CAMERA.fov = lerp(CAMERA.fov, 85.0, 0.3)
 	else:
-		CAMERA.fov = lerp(CAMERA.fov, 75.0, 0.3)
+		CAMERA.fov = lerp(CAMERA.fov, 70.0, 0.3)
 
 
 func headbob_animation(moving):

--- a/addons/walk-mode/walk-mode.gd
+++ b/addons/walk-mode/walk-mode.gd
@@ -50,6 +50,13 @@ func _forward_3d_gui_input(_camera: Camera3D, event: InputEvent):
 			if(character_spawned == false):
 				return
 			
+			var walk_camera = character.find_child("Camera", true, false)
+			if walk_camera:
+				var cam_transform : Transform3D = walk_camera.global_transform
+				var forward_direction = cam_transform.basis.z.normalized()
+				cam_transform.origin -= forward_direction * 2.5
+				_camera.global_transform = cam_transform
+			
 			canvas_viewport.gui_disable_input = true
 			Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 			get_tree().edited_scene_root.remove_child(character)
@@ -65,6 +72,9 @@ func _forward_3d_gui_input(_camera: Camera3D, event: InputEvent):
 			InputMap.load_from_project_settings()
 			Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 			character = load(ProjectSettings.get_setting("addons/walk_mode/character/path")).instantiate()
+			var spawn_transform = _camera.global_transform
+			spawn_transform.origin -= spawn_transform.basis.y * 1.5
+			character.global_transform = spawn_transform
 			get_tree().edited_scene_root.add_child(character)
 			character_spawned = true
 			RenderingServer.viewport_attach_camera(node3d_viewport.get_viewport_rid(),character.find_children("*","Camera3D",true)[0].get_camera_rid())

--- a/addons/walk-mode/walk-mode.gd
+++ b/addons/walk-mode/walk-mode.gd
@@ -50,13 +50,8 @@ func _forward_3d_gui_input(_camera: Camera3D, event: InputEvent):
 			if(character_spawned == false):
 				return
 			
-			var walk_camera = character.find_child("Camera", true, false)
-			if walk_camera:
-				var cam_transform : Transform3D = walk_camera.global_transform
-				var forward_direction = cam_transform.basis.z.normalized()
-				cam_transform.origin -= forward_direction * 2.5
-				_camera.global_transform = cam_transform
-			
+			var walk_camera : Camera3D = character.find_child("Camera", true, false)
+			_camera.global_transform  = walk_camera.global_transform		
 			canvas_viewport.gui_disable_input = true
 			Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 			get_tree().edited_scene_root.remove_child(character)

--- a/src/BoxSpawner/box_spawner.gd
+++ b/src/BoxSpawner/box_spawner.gd
@@ -43,6 +43,7 @@ func _enter_tree() -> void:
 func _ready() -> void:
 	SimulationEvents.simulation_started.connect(_on_simulation_started)
 	SimulationEvents.simulation_ended.connect(_on_simulation_ended)
+	change_texture()
 
 func _physics_process(delta: float) -> void:
 	if disable || _conveyor_stopped || not SimulationEvents.simulation_running:


### PR DESCRIPTION
Added the ability to spawn the character at the current free-fly camera position, and return to free-fly mode at the character’s last camera location.

Fixes #153 